### PR TITLE
[3] DBスキーマとマイグレーション

### DIFF
--- a/src-tauri/migrations/001_create_initial_tables.sql
+++ b/src-tauri/migrations/001_create_initial_tables.sql
@@ -1,0 +1,53 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS works (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    title      TEXT    NOT NULL,
+    path       TEXT    NOT NULL UNIQUE,
+    type       TEXT    NOT NULL CHECK (type IN ('image', 'pdf', 'archive')),
+    page_count INTEGER,
+    thumbnail  BLOB,
+    created_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_works_type       ON works(type);
+CREATE INDEX IF NOT EXISTS idx_works_title      ON works(title);
+CREATE INDEX IF NOT EXISTS idx_works_created_at ON works(created_at);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    name     TEXT NOT NULL,
+    category TEXT,
+    UNIQUE(name, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_category ON tags(category);
+CREATE INDEX IF NOT EXISTS idx_tags_name     ON tags(name);
+
+CREATE TABLE IF NOT EXISTS works_tags (
+    work_id INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (work_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_works_tags_tag_id ON works_tags(tag_id);
+
+CREATE TABLE IF NOT EXISTS playlists (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS playlist_items (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+    work_id     INTEGER NOT NULL REFERENCES works(id)     ON DELETE CASCADE,
+    position    INTEGER NOT NULL,
+    UNIQUE(playlist_id, work_id),
+    UNIQUE(playlist_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_playlist_items_work_id  ON playlist_items(work_id);
+CREATE INDEX IF NOT EXISTS idx_playlist_items_position ON playlist_items(playlist_id, position);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
@@ -5,9 +7,20 @@ fn greet(name: &str) -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let migrations = vec![Migration {
+        version: 1,
+        description: "create_initial_tables",
+        sql: include_str!("../migrations/001_create_initial_tables.sql"),
+        kind: MigrationKind::Up,
+    }];
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(
+            tauri_plugin_sql::Builder::default()
+                .add_migrations("sqlite:sharaku.db", migrations)
+                .build(),
+        )
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![greet])


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/3

# 変更点

- `src-tauri/migrations/001_create_initial_tables.sql` を新規作成（5テーブル: works, tags, works_tags, playlists, playlist_items + 8インデックス）
- `src-tauri/src/lib.rs` に `tauri-plugin-sql` のマイグレーション登録処理を追加（`include_str!` でSQL埋め込み、`add_migrations` で登録）

# 備考

- `PRAGMA foreign_keys = ON` はマイグレーション実行時の接続でのみ有効。通常接続時の設定は後続Issueで対応