### PR TITLE
[4] 画像スキャン・登録 + サムネイル生成（画像のみ）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +432,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -461,6 +481,12 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -959,6 +985,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1534,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1500,6 +1557,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -1687,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1802,6 +1868,34 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1921,6 +2015,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2061,6 +2165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libwebp-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
+dependencies = [
+ "cc",
+ "glob",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2291,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,7 +2315,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2845,6 +2969,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3102,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3231,6 +3383,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3557,6 +3723,8 @@ dependencies = [
 name = "sharaku"
 version = "0.1.0"
 dependencies = [
+ "image",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -3565,6 +3733,10 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
+ "thiserror 2.0.18",
+ "tokio",
+ "walkdir",
+ "webp",
 ]
 
 [[package]]
@@ -3733,7 +3905,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.13.0",
  "log",
  "memchr",
@@ -4160,7 +4332,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4737,7 +4909,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5155,6 +5327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
+dependencies = [
+ "image",
+ "libwebp-sys",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5189,6 +5371,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -6048,6 +6236,21 @@ name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,3 +20,9 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp", "bmp"] }
+webp = "0.3"
+rusqlite = { version = "0.32", features = ["bundled"] }
+walkdir = "2"
+thiserror = "2"
+tokio = { version = "1", features = ["sync"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "sql:default",
     "sql:allow-execute",
     "fs:default",
-    "dialog:default"
+    "dialog:default",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::error::ScanError;
+
+pub fn open_db(app_data_dir: &Path) -> Result<Connection, ScanError> {
+    std::fs::create_dir_all(app_data_dir)?;
+    let db_path = app_data_dir.join("sharaku.db");
+    let conn = Connection::open(db_path)?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    conn.execute_batch(include_str!("../migrations/001_create_initial_tables.sql"))?;
+    Ok(conn)
+}
+
+pub fn path_exists(conn: &Connection, path: &str) -> Result<bool, ScanError> {
+    let mut stmt = conn.prepare_cached("SELECT 1 FROM works WHERE path = ?1")?;
+    Ok(stmt.exists([path])?)
+}
+
+pub struct WorkRecord<'a> {
+    pub title: &'a str,
+    pub path: &'a str,
+    pub work_type: &'a str,
+    pub page_count: i32,
+    pub thumbnail: &'a [u8],
+}
+
+pub fn insert_work(conn: &Connection, record: &WorkRecord) -> Result<(), ScanError> {
+    conn.execute(
+        "INSERT INTO works (title, path, type, page_count, thumbnail) VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![
+            record.title,
+            record.path,
+            record.work_type,
+            record.page_count,
+            record.thumbnail,
+        ],
+    )?;
+    Ok(())
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ScanError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Image error: {0}")]
+    Image(#[from] image::ImageError),
+
+    #[error("Database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error("WebP encode failed")]
+    WebpEncode,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,36 @@
+mod db;
+mod error;
+mod scanner;
+mod thumbnail;
+
+use std::path::PathBuf;
+
+use tauri::Manager;
 use tauri_plugin_sql::{Migration, MigrationKind};
 
+use scanner::ScanProgress;
+
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+async fn scan_library(
+    app: tauri::AppHandle,
+    root_path: String,
+    on_progress: tauri::ipc::Channel<ScanProgress>,
+) -> Result<(), String> {
+    let app_data_dir: PathBuf = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    let root = PathBuf::from(root_path);
+
+    tokio::task::spawn_blocking(move || {
+        let result = scanner::scan_directory(&root, &app_data_dir, &on_progress);
+        if let Err(ref e) = result {
+            let _ = on_progress.send(ScanProgress::Error {
+                message: e.to_string(),
+            });
+        }
+        result
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -23,7 +51,7 @@ pub fn run() {
         )
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![scan_library])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+use walkdir::WalkDir;
+
+use crate::db::{self, WorkRecord};
+use crate::error::ScanError;
+use crate::thumbnail;
+
+const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp"];
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum ScanProgress {
+    Started {
+        total: usize,
+    },
+    Processing {
+        current: usize,
+        total: usize,
+        file_name: String,
+    },
+    Completed {
+        registered: usize,
+        failed: usize,
+    },
+    Error {
+        message: String,
+    },
+}
+
+fn is_image_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+pub fn scan_directory(
+    root: &Path,
+    app_data_dir: &Path,
+    on_progress: &Channel<ScanProgress>,
+) -> Result<(), ScanError> {
+    let mut walk_errors = 0usize;
+    let image_files: Vec<_> = WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| match e {
+            Ok(entry) => Some(entry),
+            Err(_) => {
+                walk_errors += 1;
+                None
+            }
+        })
+        .filter(|e| e.file_type().is_file() && is_image_file(e.path()))
+        .collect();
+
+    let total = image_files.len();
+    let _ = on_progress.send(ScanProgress::Started { total });
+
+    let conn = db::open_db(app_data_dir)?;
+    let mut registered = 0usize;
+    let mut failed = walk_errors;
+
+    for (i, entry) in image_files.iter().enumerate() {
+        let path = entry.path();
+        let file_name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        let _ = on_progress.send(ScanProgress::Processing {
+            current: i + 1,
+            total,
+            file_name,
+        });
+
+        let path_str = path.to_string_lossy();
+        if db::path_exists(&conn, &path_str)? {
+            continue;
+        }
+
+        let thumb = match thumbnail::generate_thumbnail(path) {
+            Ok(data) => data,
+            Err(_) => {
+                failed += 1;
+                continue;
+            }
+        };
+
+        let title = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        db::insert_work(
+            &conn,
+            &WorkRecord {
+                title: &title,
+                path: &path_str,
+                work_type: "image",
+                page_count: 1,
+                thumbnail: &thumb,
+            },
+        )?;
+
+        registered += 1;
+    }
+
+    let _ = on_progress.send(ScanProgress::Completed { registered, failed });
+    Ok(())
+}

--- a/src-tauri/src/thumbnail.rs
+++ b/src-tauri/src/thumbnail.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use image::imageops::FilterType;
+use image::GenericImageView;
+
+use crate::error::ScanError;
+
+const MAX_WIDTH: u32 = 200;
+const MAX_HEIGHT: u32 = 280;
+const WEBP_QUALITY: f32 = 65.0;
+
+pub fn generate_thumbnail(image_path: &Path) -> Result<Vec<u8>, ScanError> {
+    let img = image::open(image_path)?;
+    let (orig_w, orig_h) = img.dimensions();
+
+    let scale = (MAX_WIDTH as f64 / orig_w as f64).min(MAX_HEIGHT as f64 / orig_h as f64);
+    let resized = if scale < 1.0 {
+        let new_w = (orig_w as f64 * scale).round() as u32;
+        let new_h = (orig_h as f64 * scale).round() as u32;
+        img.resize_exact(new_w, new_h, FilterType::Triangle)
+    } else {
+        img.clone()
+    };
+
+    let rgba = resized.to_rgba8();
+    let (w, h) = rgba.dimensions();
+    let encoder = webp::Encoder::from_rgba(&rgba, w, h);
+    let mem = encoder.encode(WEBP_QUALITY);
+
+    if mem.is_empty() {
+        return Err(ScanError::WebpEncode);
+    }
+
+    Ok(mem.to_vec())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost data:"
     }
   },
   "bundle": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,21 +1,26 @@
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
+  import ScanButton from "./lib/components/ScanButton.svelte";
+  import ScanProgressBar from "./lib/components/ScanProgress.svelte";
+  import WorkGrid from "./lib/components/WorkGrid.svelte";
+  import type { ScanProgress } from "./lib/types";
 
-  let name = $state("");
-  let greetMsg = $state("");
+  let progress = $state<ScanProgress | null>(null);
+  let reloadTrigger = $state(0);
 
-  async function greet(event: Event) {
-    event.preventDefault();
-    greetMsg = await invoke("greet", { name });
+  function handleProgress(p: ScanProgress) {
+    progress = p;
+  }
+
+  function handleComplete() {
+    reloadTrigger++;
   }
 </script>
 
 <main class="container">
-  <h1>Welcome to Sharaku</h1>
-
-  <form class="row" onsubmit={greet}>
-    <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
-    <button type="submit">Greet</button>
-  </form>
-  <p>{greetMsg}</p>
+  <h1>Sharaku</h1>
+  <div class="controls">
+    <ScanButton onProgress={handleProgress} onComplete={handleComplete} />
+  </div>
+  <ScanProgressBar {progress} />
+  <WorkGrid {reloadTrigger} />
 </main>

--- a/src/app.css
+++ b/src/app.css
@@ -15,24 +15,15 @@
 }
 
 .container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-}
-
-.row {
-  display: flex;
-  justify-content: center;
+  margin: 0 auto;
+  padding: 24px;
+  max-width: 1200px;
 }
 
 h1 {
-  text-align: center;
+  margin: 0 0 16px;
 }
 
-input,
 button {
   border-radius: 8px;
   border: 1px solid transparent;
@@ -42,12 +33,9 @@ button {
   font-family: inherit;
   color: #0f0f0f;
   background-color: #ffffff;
+  cursor: pointer;
   transition: border-color 0.25s;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
 }
 
 button:hover {
@@ -59,13 +47,89 @@ button:active {
   background-color: #e8e8e8;
 }
 
-input,
-button {
-  outline: none;
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
-#greet-input {
-  margin-right: 5px;
+.controls {
+  margin-bottom: 16px;
+}
+
+.scan-progress {
+  margin-bottom: 16px;
+}
+
+.scan-progress progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  appearance: none;
+}
+
+.scan-progress progress::-webkit-progress-bar {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+}
+
+.scan-progress progress::-webkit-progress-value {
+  background-color: #396cd8;
+  border-radius: 4px;
+}
+
+.scan-progress p {
+  margin: 4px 0;
+  font-size: 0.875rem;
+}
+
+.scan-progress .completed {
+  color: #2e7d32;
+}
+
+.scan-progress .error {
+  color: #c62828;
+}
+
+.work-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.work-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.work-card img {
+  width: 100%;
+  aspect-ratio: 5 / 7;
+  object-fit: cover;
+  border-radius: 4px;
+  background-color: #e0e0e0;
+}
+
+.work-card .no-thumbnail {
+  width: 100%;
+  aspect-ratio: 5 / 7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  color: #888;
+  font-size: 0.75rem;
+}
+
+.work-title {
+  font-size: 0.75rem;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -74,7 +138,6 @@ button {
     background-color: #2f2f2f;
   }
 
-  input,
   button {
     color: #ffffff;
     background-color: #0f0f0f98;
@@ -82,5 +145,18 @@ button {
 
   button:active {
     background-color: #0f0f0f69;
+  }
+
+  .scan-progress progress::-webkit-progress-bar {
+    background-color: #444;
+  }
+
+  .work-card img {
+    background-color: #444;
+  }
+
+  .work-card .no-thumbnail {
+    background-color: #444;
+    color: #aaa;
   }
 }

--- a/src/lib/components/ScanButton.svelte
+++ b/src/lib/components/ScanButton.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { invoke, Channel } from "@tauri-apps/api/core";
+  import { open } from "@tauri-apps/plugin-dialog";
+  import type { ScanProgress } from "../types";
+
+  interface Props {
+    onProgress: (progress: ScanProgress) => void;
+    onComplete: () => void;
+  }
+
+  let { onProgress, onComplete }: Props = $props();
+  let scanning = $state(false);
+
+  async function handleScan() {
+    const selected = await open({ directory: true, multiple: false });
+    if (!selected) return;
+
+    scanning = true;
+    const channel = new Channel<ScanProgress>();
+    channel.onmessage = (progress) => {
+      onProgress(progress);
+      if (progress.type === "completed" || progress.type === "error") {
+        scanning = false;
+        onComplete();
+      }
+    };
+
+    try {
+      await invoke("scan_library", { rootPath: selected, onProgress: channel });
+    } catch (e) {
+      scanning = false;
+      onProgress({ type: "error", message: String(e) });
+    }
+  }
+</script>
+
+<button class="scan-button" onclick={handleScan} disabled={scanning}>
+  {scanning ? "スキャン中..." : "フォルダをスキャン"}
+</button>

--- a/src/lib/components/ScanProgress.svelte
+++ b/src/lib/components/ScanProgress.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { ScanProgress } from "../types";
+
+  interface Props {
+    progress: ScanProgress | null;
+  }
+
+  let { progress }: Props = $props();
+</script>
+
+{#if progress}
+  <div class="scan-progress">
+    {#if progress.type === "started"}
+      <p>{progress.total} 件のファイルを検出</p>
+      <progress max={progress.total} value={0}></progress>
+    {:else if progress.type === "processing"}
+      <p>{progress.current} / {progress.total}: {progress.fileName}</p>
+      <progress max={progress.total} value={progress.current}></progress>
+    {:else if progress.type === "completed"}
+      <p class="completed">完了: {progress.registered} 件登録, {progress.failed} 件失敗</p>
+    {:else if progress.type === "error"}
+      <p class="error">エラー: {progress.message}</p>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/WorkGrid.svelte
+++ b/src/lib/components/WorkGrid.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { getDatabase } from "../db/database";
+  import type { Work } from "../types";
+
+  interface Props {
+    reloadTrigger: number;
+  }
+
+  let { reloadTrigger }: Props = $props();
+  let works = $state<Work[]>([]);
+
+  function thumbnailToDataUrl(bytes: number[]): string {
+    const u8 = new Uint8Array(bytes);
+    const chunk = 8192;
+    let binary = "";
+    for (let i = 0; i < u8.length; i += chunk) {
+      binary += String.fromCharCode(...u8.subarray(i, i + chunk));
+    }
+    return `data:image/webp;base64,${btoa(binary)}`;
+  }
+
+  async function loadWorks() {
+    const db = await getDatabase();
+    works = await db.select<Work[]>(
+      "SELECT id, title, thumbnail FROM works ORDER BY created_at DESC"
+    );
+  }
+
+  $effect(() => {
+    void reloadTrigger;
+    loadWorks();
+  });
+</script>
+
+<div class="work-grid">
+  {#each works as work (work.id)}
+    <div class="work-card">
+      {#if work.thumbnail && work.thumbnail.length > 0}
+        <img src={thumbnailToDataUrl(work.thumbnail)} alt={work.title} />
+      {:else}
+        <div class="no-thumbnail">No Image</div>
+      {/if}
+      <span class="work-title">{work.title}</span>
+    </div>
+  {/each}
+</div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,11 @@
+export type ScanProgress =
+  | { type: "started"; total: number }
+  | { type: "processing"; current: number; total: number; fileName: string }
+  | { type: "completed"; registered: number; failed: number }
+  | { type: "error"; message: string };
+
+export interface Work {
+  id: number;
+  title: string;
+  thumbnail: number[];
+}


### PR DESCRIPTION
# Issue

closes #4 (画像のみスコープ。PDF → #14、ZIP/CBZ → #15 に分離済み)

# 変更点

- 指定フォルダ内の画像ファイル（jpg/jpeg/png/gif/webp/bmp）を再帰スキャンし、WebPサムネイルを生成してworksテーブルに登録する機能を実装
- Tauri v2 Channel APIでスキャン進捗をフロントエンドにリアルタイム通知
- Rustバックエンド: error.rs, db.rs, thumbnail.rs, scanner.rsを新規追加
- フロントエンド: ScanButton, ScanProgress, WorkGridコンポーネントを新規追加
- CSPにdata:を追加（サムネイルdata URL表示用）、capabilitiesにdialog:allow-openを追加

# 備考

- PDF/ZIP/CBZ対応は別Issue（#14, #15）で実装予定
- rusqlite (bundled)をRustコマンド内でのDB直接操作用に追加（tauri-plugin-sqlはフロントエンド向けAPI）
- webpクレートでlossy WebPエンコード（品質65）を使用
- 破損ファイルはスキップしてfailedカウントに加算、再スキャンでは重複登録されない