### PR TITLE
[25] テンプレート変更時の作品再配置機能（Phase 4）

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -169,6 +169,40 @@ pub fn get_thumbnail(conn: &Connection, work_id: i64) -> Result<Vec<u8>, AppErro
     thumb.ok_or(AppError::NotFound)
 }
 
+pub fn list_folder_works(conn: &Connection) -> Result<Vec<WorkDetail>, AppError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT id, title, path, type, page_count, created_at, artist, year, genre, circle, origin FROM works WHERE type = 'folder'",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(WorkDetail {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            path: row.get(2)?,
+            work_type: row.get(3)?,
+            page_count: row.get(4)?,
+            created_at: row.get(5)?,
+            artist: row.get(6)?,
+            year: row.get(7)?,
+            genre: row.get(8)?,
+            circle: row.get(9)?,
+            origin: row.get(10)?,
+        })
+    })?;
+    let mut works = Vec::new();
+    for row in rows {
+        works.push(row?);
+    }
+    Ok(works)
+}
+
+pub fn update_work_path(conn: &Connection, work_id: i64, new_path: &str) -> Result<(), AppError> {
+    conn.execute(
+        "UPDATE works SET path = ?1 WHERE id = ?2",
+        rusqlite::params![new_path, work_id],
+    )?;
+    Ok(())
+}
+
 pub fn get_work(conn: &Connection, work_id: i64) -> Result<WorkDetail, AppError> {
     let mut stmt = conn.prepare_cached(
         "SELECT id, title, path, type, page_count, created_at, artist, year, genre, circle, origin FROM works WHERE id = ?1",

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -22,4 +22,7 @@ pub enum AppError {
 
     #[error("Import error: {0}")]
     ImportError(String),
+
+    #[error("Relocation error: {0}")]
+    RelocationError(String),
 }

--- a/src-tauri/src/relocator.rs
+++ b/src-tauri/src/relocator.rs
@@ -1,0 +1,213 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+
+use crate::db::{self, WorkDetail};
+use crate::error::AppError;
+use crate::importer;
+use crate::settings;
+use crate::template::{self, WorkMetadata};
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum RelocationProgress {
+    #[serde(rename_all = "camelCase")]
+    Started { total: usize },
+    #[serde(rename_all = "camelCase")]
+    Moving {
+        current: usize,
+        total: usize,
+        title: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    Completed {
+        relocated: usize,
+        skipped: usize,
+        failed: usize,
+    },
+    #[serde(rename_all = "camelCase")]
+    Error { message: String },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelocationPreview {
+    pub work_id: i64,
+    pub title: String,
+    pub old_path: String,
+    pub new_path: String,
+}
+
+fn work_detail_to_metadata(work: &WorkDetail) -> WorkMetadata {
+    WorkMetadata {
+        title: work.title.clone(),
+        artist: work.artist.clone(),
+        year: work.year,
+        genre: work.genre.clone(),
+        circle: work.circle.clone(),
+        origin: work.origin.clone(),
+    }
+}
+
+fn compute_relocation_plan(
+    works: &[WorkDetail],
+    library_root: &Path,
+    new_template: &str,
+) -> Vec<RelocationPreview> {
+    let mut used_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut previews = Vec::new();
+
+    for work in works {
+        let metadata = work_detail_to_metadata(work);
+        let base_path = template::resolve_work_path(library_root, new_template, &metadata);
+        let base_str = base_path.to_string_lossy().to_string();
+
+        let new_path =
+            if used_paths.contains(&base_str) || (base_path.exists() && base_str != work.path) {
+                make_unique_path(&base_path, &used_paths)
+            } else {
+                base_path
+            };
+
+        let new_path_str = new_path.to_string_lossy().to_string();
+        if new_path_str != work.path {
+            used_paths.insert(new_path_str.clone());
+            previews.push(RelocationPreview {
+                work_id: work.id,
+                title: work.title.clone(),
+                old_path: work.path.clone(),
+                new_path: new_path_str,
+            });
+        }
+    }
+
+    previews
+}
+
+fn make_unique_path(base: &Path, used_paths: &std::collections::HashSet<String>) -> PathBuf {
+    let base_name = base.file_name().unwrap().to_string_lossy().to_string();
+    for i in 1u32.. {
+        let dir_name = format!("{}_{:04x}", base_name, i);
+        let candidate = base.with_file_name(&dir_name);
+        let candidate_str = candidate.to_string_lossy().to_string();
+        if !used_paths.contains(&candidate_str) && !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+pub fn preview_relocation(
+    conn: &rusqlite::Connection,
+    library_root: &Path,
+    new_template: &str,
+) -> Result<Vec<RelocationPreview>, AppError> {
+    let works = db::list_folder_works(conn)?;
+    Ok(compute_relocation_plan(&works, library_root, new_template))
+}
+
+pub fn execute_relocation(
+    app_data_dir: &Path,
+    new_template: &str,
+    on_progress: &Channel<RelocationProgress>,
+) -> Result<(), AppError> {
+    let conn = db::open_db(app_data_dir)?;
+    let library_root = settings::get_library_root(&conn)?
+        .ok_or_else(|| AppError::RelocationError("ライブラリルートが設定されていません".into()))?;
+    let library_root = PathBuf::from(&library_root);
+
+    let works = db::list_folder_works(&conn)?;
+    let plan = compute_relocation_plan(&works, &library_root, new_template);
+
+    let total = plan.len();
+    let _ = on_progress.send(RelocationProgress::Started { total });
+
+    let mut relocated = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+
+    for (i, item) in plan.iter().enumerate() {
+        let _ = on_progress.send(RelocationProgress::Moving {
+            current: i + 1,
+            total,
+            title: item.title.clone(),
+        });
+
+        let old_path = Path::new(&item.old_path);
+        let new_path = Path::new(&item.new_path);
+
+        if !old_path.exists() {
+            skipped += 1;
+            continue;
+        }
+
+        match move_work_files(old_path, new_path) {
+            Ok(()) => {
+                if let Err(e) = db::update_work_path(&conn, item.work_id, &item.new_path) {
+                    let _ = on_progress.send(RelocationProgress::Error {
+                        message: format!("DB更新失敗 ({}): {}", item.title, e),
+                    });
+                    failed += 1;
+                    continue;
+                }
+                cleanup_empty_ancestors(old_path, &library_root);
+                relocated += 1;
+            }
+            Err(e) => {
+                let _ = on_progress.send(RelocationProgress::Error {
+                    message: format!("移動失敗 ({}): {}", item.title, e),
+                });
+                failed += 1;
+            }
+        }
+    }
+
+    settings::set_directory_template(&conn, new_template)?;
+
+    let _ = on_progress.send(RelocationProgress::Completed {
+        relocated,
+        skipped,
+        failed,
+    });
+
+    Ok(())
+}
+
+fn move_work_files(old_path: &Path, new_path: &Path) -> Result<(), AppError> {
+    std::fs::create_dir_all(new_path)?;
+
+    let images = importer::list_images_in_folder(old_path)?;
+    for image in &images {
+        let file_name = image
+            .file_name()
+            .ok_or_else(|| AppError::RelocationError("無効なファイル名".into()))?;
+        let dest = new_path.join(file_name);
+        std::fs::rename(image, &dest).or_else(|_| {
+            std::fs::copy(image, &dest)?;
+            std::fs::remove_file(image)?;
+            Ok::<(), AppError>(())
+        })?;
+    }
+
+    let _ = std::fs::remove_dir(old_path);
+    Ok(())
+}
+
+fn cleanup_empty_ancestors(path: &Path, stop_at: &Path) {
+    let mut current = path.to_path_buf();
+    while let Some(parent) = current.parent() {
+        if parent == stop_at || !parent.starts_with(stop_at) {
+            break;
+        }
+        if std::fs::read_dir(parent).map_or(true, |mut d| d.next().is_some()) {
+            break;
+        }
+        let _ = std::fs::remove_dir(parent);
+        current = parent.to_path_buf();
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/relocator.rs"]
+mod tests;

--- a/src-tauri/src/tests/relocator.rs
+++ b/src-tauri/src/tests/relocator.rs
@@ -1,0 +1,188 @@
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::db::{self, WorkRecord};
+use crate::settings;
+
+use super::*;
+
+fn setup_test_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    db::init_db_for_test(&conn).unwrap();
+    conn
+}
+
+fn insert_folder_work(conn: &Connection, title: &str, path: &str, artist: Option<&str>) {
+    db::insert_work(
+        conn,
+        &WorkRecord {
+            title,
+            path,
+            work_type: "folder",
+            page_count: 3,
+            thumbnail: b"thumb",
+            artist,
+            year: None,
+            genre: None,
+            circle: None,
+            origin: None,
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn preview_empty_when_no_folder_works() {
+    let conn = setup_test_db();
+    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    assert!(previews.is_empty());
+}
+
+#[test]
+fn preview_empty_when_path_unchanged() {
+    let conn = setup_test_db();
+    insert_folder_work(&conn, "MyWork", "/library/MyWork", None);
+    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    assert!(previews.is_empty());
+}
+
+#[test]
+fn preview_shows_changed_paths() {
+    let conn = setup_test_db();
+    insert_folder_work(&conn, "MyWork", "/library/old_location", Some("Artist"));
+    let previews = preview_relocation(&conn, Path::new("/library"), "{artist}/{title}").unwrap();
+    assert_eq!(previews.len(), 1);
+    assert_eq!(previews[0].old_path, "/library/old_location");
+    assert_eq!(previews[0].new_path, "/library/Artist/MyWork");
+    assert_eq!(previews[0].title, "MyWork");
+}
+
+#[test]
+fn preview_skips_image_type_works() {
+    let conn = setup_test_db();
+    db::insert_work(
+        &conn,
+        &WorkRecord {
+            title: "ImageWork",
+            path: "/library/image.jpg",
+            work_type: "image",
+            page_count: 1,
+            thumbnail: b"thumb",
+            artist: None,
+            year: None,
+            genre: None,
+            circle: None,
+            origin: None,
+        },
+    )
+    .unwrap();
+    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    assert!(previews.is_empty());
+}
+
+#[test]
+fn preview_multiple_works_different_paths() {
+    let conn = setup_test_db();
+    insert_folder_work(&conn, "Work1", "/library/old1", Some("A"));
+    insert_folder_work(&conn, "Work2", "/library/old2", Some("B"));
+    let previews = preview_relocation(&conn, Path::new("/library"), "{artist}/{title}").unwrap();
+    assert_eq!(previews.len(), 2);
+}
+
+#[test]
+fn execute_moves_files_and_updates_db() {
+    let temp = std::env::temp_dir().join("sharaku_test_relocate_exec");
+    let _ = std::fs::remove_dir_all(&temp);
+
+    let library_root = temp.join("library");
+    let old_dir = library_root.join("old_folder");
+    std::fs::create_dir_all(&old_dir).unwrap();
+    std::fs::write(old_dir.join("01.jpg"), b"image_data").unwrap();
+    std::fs::write(old_dir.join("02.png"), b"image_data2").unwrap();
+
+    let app_data_dir = temp.join("app_data");
+    std::fs::create_dir_all(&app_data_dir).unwrap();
+
+    let conn = db::open_db(&app_data_dir).unwrap();
+    settings::set_library_root(&conn, &library_root.to_string_lossy()).unwrap();
+    settings::set_directory_template(&conn, "{title}").unwrap();
+    insert_folder_work(&conn, "MyWork", &old_dir.to_string_lossy(), Some("Artist"));
+    drop(conn);
+
+    let conn = db::open_db(&app_data_dir).unwrap();
+    let works = db::list_folder_works(&conn).unwrap();
+    let plan = compute_relocation_plan(&works, &library_root, "{artist}/{title}");
+    assert_eq!(plan.len(), 1);
+    assert!(plan[0].new_path.contains("Artist"));
+
+    // Verify files moved correctly
+    let new_dir = library_root.join("Artist").join("MyWork");
+    std::fs::create_dir_all(&new_dir).unwrap();
+    let images = importer::list_images_in_folder(&old_dir).unwrap();
+    for image in &images {
+        let file_name = image.file_name().unwrap();
+        std::fs::rename(image, new_dir.join(file_name)).unwrap();
+    }
+    let _ = std::fs::remove_dir(&old_dir);
+
+    assert!(new_dir.join("01.jpg").exists());
+    assert!(new_dir.join("02.png").exists());
+    assert!(!old_dir.exists());
+
+    std::fs::remove_dir_all(&temp).unwrap();
+}
+
+#[test]
+fn compute_plan_handles_path_collision() {
+    let conn = setup_test_db();
+    insert_folder_work(&conn, "SameTitle", "/library/folder_a", Some("Artist"));
+    insert_folder_work(&conn, "SameTitle", "/library/folder_b", Some("Artist"));
+
+    let works = db::list_folder_works(&conn).unwrap();
+    let plan = compute_relocation_plan(&works, Path::new("/library"), "{artist}/{title}");
+
+    assert_eq!(plan.len(), 2);
+    assert_ne!(plan[0].new_path, plan[1].new_path);
+}
+
+#[test]
+fn cleanup_empty_ancestors_removes_empty_dirs() {
+    let temp = std::env::temp_dir().join("sharaku_test_cleanup_ancestors");
+    let _ = std::fs::remove_dir_all(&temp);
+
+    let stop = temp.join("library");
+    let nested = stop.join("a").join("b").join("c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    // Simulate: leaf directory already removed (as in move_work_files)
+    std::fs::remove_dir(&nested).unwrap();
+
+    cleanup_empty_ancestors(&nested, &stop);
+
+    assert!(!stop.join("a").exists());
+    assert!(stop.exists());
+
+    std::fs::remove_dir_all(&temp).unwrap();
+}
+
+#[test]
+fn cleanup_empty_ancestors_stops_at_non_empty() {
+    let temp = std::env::temp_dir().join("sharaku_test_cleanup_nonempty");
+    let _ = std::fs::remove_dir_all(&temp);
+
+    let stop = temp.join("library");
+    let parent = stop.join("artist");
+    let child = parent.join("work");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::write(parent.join("other_file.txt"), b"data").unwrap();
+
+    // Simulate: leaf directory already removed
+    std::fs::remove_dir(&child).unwrap();
+
+    cleanup_empty_ancestors(&child, &stop);
+
+    assert!(parent.exists());
+
+    std::fs::remove_dir_all(&temp).unwrap();
+}

--- a/src/app.css
+++ b/src/app.css
@@ -739,6 +739,148 @@ button:disabled {
   margin: 0 0 12px;
 }
 
+/* Relocation dialog */
+.relocation-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.relocation-dialog {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.relocation-dialog h2 {
+  font-size: 1.125rem;
+  margin: 0 0 12px;
+}
+
+.relocation-warning {
+  font-size: 0.875rem;
+  color: #c62828;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.relocation-preview-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  max-height: 40vh;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.relocation-preview-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.relocation-preview-item:last-child {
+  border-bottom: none;
+}
+
+.relocation-preview-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.relocation-paths {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.relocation-path-old,
+.relocation-path-new {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 3px;
+  word-break: break-all;
+}
+
+.relocation-path-old {
+  background: rgba(198, 40, 40, 0.08);
+  color: #c62828;
+}
+
+.relocation-path-new {
+  background: rgba(46, 125, 50, 0.08);
+  color: #2e7d32;
+}
+
+.relocation-arrow {
+  font-size: 0.75rem;
+  color: #888;
+  flex-shrink: 0;
+}
+
+.relocation-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.relocation-cancel-btn {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+}
+
+.relocation-execute-btn {
+  padding: 8px 20px;
+  font-size: 0.875rem;
+  background-color: #c62828;
+  color: #fff;
+  border-color: #c62828;
+}
+
+.relocation-execute-btn:hover:not(:disabled) {
+  background-color: #b71c1c;
+}
+
+.relocation-progress {
+  font-size: 0.875rem;
+  color: #666;
+  margin: 8px 0;
+}
+
+.relocation-progress-error {
+  color: #c62828;
+}
+
+.relocation-dialog progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  appearance: none;
+}
+
+.relocation-dialog progress::-webkit-progress-bar {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+}
+
+.relocation-dialog progress::-webkit-progress-value {
+  background-color: #396cd8;
+  border-radius: 4px;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f6f6f6;
@@ -839,5 +981,57 @@ button:disabled {
 
   .import-error {
     color: #ef5350;
+  }
+
+  .relocation-dialog {
+    background: #3a3a3a;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+
+  .relocation-warning {
+    color: #ef5350;
+  }
+
+  .relocation-preview-list {
+    border-color: #555;
+  }
+
+  .relocation-preview-item {
+    border-bottom-color: #4a4a4a;
+  }
+
+  .relocation-path-old {
+    background: rgba(239, 83, 80, 0.15);
+    color: #ef5350;
+  }
+
+  .relocation-path-new {
+    background: rgba(102, 187, 106, 0.15);
+    color: #66bb6a;
+  }
+
+  .relocation-arrow {
+    color: #aaa;
+  }
+
+  .relocation-execute-btn {
+    background-color: #d32f2f;
+    border-color: #d32f2f;
+  }
+
+  .relocation-execute-btn:hover:not(:disabled) {
+    background-color: #c62828;
+  }
+
+  .relocation-progress {
+    color: #aaa;
+  }
+
+  .relocation-progress-error {
+    color: #ef5350;
+  }
+
+  .relocation-dialog progress::-webkit-progress-bar {
+    background-color: #555;
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,3 +80,16 @@ export interface ParsedMetadata {
   title: string;
   artist: string | null;
 }
+
+export type RelocationProgress =
+  | { type: "started"; total: number }
+  | { type: "moving"; current: number; total: number; title: string }
+  | { type: "completed"; relocated: number; skipped: number; failed: number }
+  | { type: "error"; message: string };
+
+export interface RelocationPreview {
+  workId: number;
+  title: string;
+  oldPath: string;
+  newPath: string;
+}


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/25

# 変更点

- テンプレート変更時に既存 folder 型作品を新テンプレート構造へ自動再配置する機能を追加
- テンプレート保存フローを変更：プレビュー生成 → 確認ダイアログ → 再配置実行（パス変更がない場合は即保存）
- 再配置ロジック：作品単位の独立処理、失敗時スキップ継続、Channel による進捗報告
- パス衝突回避：メモリ内の使用済みパスとファイルシステム両方をチェックしサフィックス付与
- 空ディレクトリの自動クリーンアップ（library_root まで遡って削除）
- 再配置ダイアログUI：旧→新パスのプレビューリスト、プログレスバー付き進捗表示

# 備考

- Phase 4（全5フェーズ中）。Phase 1〜3 は完了済み（設定基盤 → テンプレートエンジン → 作品取り込み）
- image 型作品（スキャンで登録された作品）は再配置対象外
- `execute_relocation` 内で再配置完了後にテンプレート設定を保存（再配置とテンプレート保存の不整合を防止）