### PR TITLE
[25] 取り込み元/先の重複チェック追加（Phase 5）

### DIFF
--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -130,6 +130,12 @@ pub fn import_work(request: &ImportRequest, app_data_dir: &Path) -> Result<Impor
     let dest =
         template::resolve_unique_work_path(Path::new(&library_root), &template_str, &metadata);
 
+    if paths_overlap(source, &dest) {
+        return Err(AppError::ImportError(
+            "取り込み元と取り込み先が重複しています".to_string(),
+        ));
+    }
+
     let thumb = thumbnail::generate_thumbnail(&images[0])?;
 
     std::fs::create_dir_all(&dest)?;
@@ -177,6 +183,10 @@ pub fn import_work(request: &ImportRequest, app_data_dir: &Path) -> Result<Impor
         destination_path: dest_str,
         page_count,
     })
+}
+
+fn paths_overlap(a: &Path, b: &Path) -> bool {
+    a.starts_with(b) || b.starts_with(a)
 }
 
 fn copy_images_to_dest(images: &[PathBuf], dest: &Path) -> Result<(), AppError> {

--- a/src-tauri/src/tests/importer.rs
+++ b/src-tauri/src/tests/importer.rs
@@ -128,3 +128,33 @@ fn preview_path_with_template() {
     let result = preview_import_path(Path::new("/library"), "{artist}/{title}", &metadata);
     assert_eq!(result, "/library/Artist/My Work");
 }
+
+// paths_overlap tests
+
+#[test]
+fn paths_overlap_identical() {
+    assert!(paths_overlap(Path::new("/a/b"), Path::new("/a/b")));
+}
+
+#[test]
+fn paths_overlap_source_contains_dest() {
+    assert!(paths_overlap(Path::new("/a"), Path::new("/a/b")));
+}
+
+#[test]
+fn paths_overlap_dest_contains_source() {
+    assert!(paths_overlap(Path::new("/a/b/c"), Path::new("/a/b")));
+}
+
+#[test]
+fn paths_overlap_disjoint() {
+    assert!(!paths_overlap(Path::new("/a/b"), Path::new("/c/d")));
+}
+
+#[test]
+fn paths_overlap_partial_name_no_overlap() {
+    assert!(!paths_overlap(
+        Path::new("/library/art"),
+        Path::new("/library/artist")
+    ));
+}


### PR DESCRIPTION
# Issue

#25

# 変更点

- 作品取り込み時に、取り込み元と取り込み先のパスが重複（包含関係）していないかチェックするガードを追加
- ライブラリルート配下のフォルダを誤って自分自身に移動/コピーするケースを防止
- 重複チェックのユニットテスト5件を追加
- マージ済みブランチ（Phase 1〜4）のローカル/リモート参照をクリーンアップ

# 備考

- `Path::starts_with` はコンポーネント単位の比較のため、部分文字列一致による誤検出はなし（テストで確認済み）
- UI変更なし（バックエンドのみの変更）