### PR TITLE
[7] タグ管理 残課題対応（Phase 3）

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1021,6 +1021,55 @@ button:disabled {
   border-radius: 4px;
 }
 
+/* Tag remove confirmation dialog */
+.tag-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+}
+
+.tag-confirm-dialog {
+  background: #fff;
+  border-radius: 10px;
+  padding: 20px 24px;
+  max-width: 340px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.tag-confirm-dialog p {
+  font-size: 0.875rem;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.tag-confirm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.tag-confirm-cancel {
+  padding: 6px 14px;
+  font-size: 0.8125rem;
+}
+
+.tag-confirm-delete {
+  padding: 6px 14px;
+  font-size: 0.8125rem;
+  background-color: #c62828;
+  color: #fff;
+  border-color: #c62828;
+}
+
+.tag-confirm-delete:hover {
+  background-color: #b71c1c;
+}
+
 /* Tag badge */
 .tag-badge {
   display: inline-flex;
@@ -1033,6 +1082,26 @@ button:disabled {
   color: #396cd8;
   white-space: nowrap;
   line-height: 1.6;
+}
+
+.tag-badge[data-category="artist"] {
+  background: rgba(216, 57, 57, 0.15);
+  color: #d83939;
+}
+
+.tag-badge[data-category="circle"] {
+  background: rgba(57, 162, 216, 0.15);
+  color: #39a2d8;
+}
+
+.tag-badge[data-category="genre"] {
+  background: rgba(57, 216, 108, 0.15);
+  color: #2e9e54;
+}
+
+.tag-badge[data-category="series"] {
+  background: rgba(216, 162, 57, 0.15);
+  color: #c88a2e;
 }
 
 .tag-badge-remove {
@@ -1105,6 +1174,21 @@ button:disabled {
   font-style: italic;
 }
 
+.tag-input-category-header {
+  padding: 4px 10px 2px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.tag-input-category-header:not(:first-child) {
+  border-top: 1px solid #e8e8e8;
+  margin-top: 2px;
+  padding-top: 6px;
+}
+
 /* TagInput dark variant */
 .tag-input-dark .tag-input-field {
   background: rgba(255, 255, 255, 0.1);
@@ -1138,6 +1222,11 @@ button:disabled {
   color: #5c93e6;
 }
 
+.tag-input-dark .tag-input-category-header {
+  color: #888;
+  border-top-color: #555;
+}
+
 /* TagInput light variant */
 .tag-input-light .tag-input-field {
   background: #fff;
@@ -1158,6 +1247,26 @@ button:disabled {
 .viewer-tag-bar .tag-badge {
   background: rgba(57, 108, 216, 0.3);
   color: #8ab4f8;
+}
+
+.viewer-tag-bar .tag-badge[data-category="artist"] {
+  background: rgba(216, 57, 57, 0.3);
+  color: #f08080;
+}
+
+.viewer-tag-bar .tag-badge[data-category="circle"] {
+  background: rgba(57, 162, 216, 0.3);
+  color: #7ec8e8;
+}
+
+.viewer-tag-bar .tag-badge[data-category="genre"] {
+  background: rgba(57, 216, 108, 0.3);
+  color: #6ed89a;
+}
+
+.viewer-tag-bar .tag-badge[data-category="series"] {
+  background: rgba(216, 162, 57, 0.3);
+  color: #e0b86e;
 }
 
 /* Filter section in toolbar */
@@ -1283,6 +1392,20 @@ button:disabled {
     color: #ef5350;
   }
 
+  .tag-confirm-dialog {
+    background: #3a3a3a;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
+
+  .tag-confirm-delete {
+    background-color: #d32f2f;
+    border-color: #d32f2f;
+  }
+
+  .tag-confirm-delete:hover {
+    background-color: #c62828;
+  }
+
   .relocation-dialog {
     background: #3a3a3a;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
@@ -1389,6 +1512,26 @@ button:disabled {
     color: #5c93e6;
   }
 
+  .tag-badge[data-category="artist"] {
+    background: rgba(216, 57, 57, 0.25);
+    color: #e87070;
+  }
+
+  .tag-badge[data-category="circle"] {
+    background: rgba(57, 162, 216, 0.25);
+    color: #5cb8e0;
+  }
+
+  .tag-badge[data-category="genre"] {
+    background: rgba(57, 216, 108, 0.25);
+    color: #5cc87e;
+  }
+
+  .tag-badge[data-category="series"] {
+    background: rgba(216, 162, 57, 0.25);
+    color: #d8a84e;
+  }
+
   .tag-input-light .tag-input-field {
     background: #3a3a3a;
     color: #f6f6f6;
@@ -1411,6 +1554,11 @@ button:disabled {
 
   .tag-input-light .tag-input-create {
     color: #5c93e6;
+  }
+
+  .tag-input-light .tag-input-category-header {
+    color: #888;
+    border-top-color: #555;
   }
 
   .filter-mode-select {

--- a/src/lib/components/TagInput.svelte
+++ b/src/lib/components/TagInput.svelte
@@ -69,6 +69,53 @@
     selectTag(tag);
   }
 
+  const CATEGORY_ORDER: Record<string, number> = {
+    artist: 0,
+    circle: 1,
+    genre: 2,
+    series: 3,
+  };
+
+  type GroupedItem =
+    | { type: "header"; category: string }
+    | { type: "tag"; tag: Tag; flatIndex: number };
+
+  let groupedItems = $derived.by(() => {
+    if (suggestions.length === 0) return [];
+
+    const sorted = [...suggestions].sort((a, b) => {
+      const catA = a.category ?? "\uffff";
+      const catB = b.category ?? "\uffff";
+      const orderA = CATEGORY_ORDER[catA] ?? 999;
+      const orderB = CATEGORY_ORDER[catB] ?? 999;
+      if (orderA !== orderB) return orderA - orderB;
+      return a.name.localeCompare(b.name);
+    });
+
+    const items: GroupedItem[] = [];
+    let currentCategory: string | undefined;
+    let flatIndex = 0;
+    for (const tag of sorted) {
+      const cat = tag.category ?? "";
+      if (cat !== currentCategory) {
+        currentCategory = cat;
+        items.push({ type: "header", category: tag.category ?? "" });
+      }
+      items.push({ type: "tag", tag, flatIndex });
+      flatIndex++;
+    }
+    return items;
+  });
+
+  let sortedSuggestions = $derived(
+    groupedItems
+      .filter(
+        (item): item is Extract<GroupedItem, { type: "tag" }> =>
+          item.type === "tag",
+      )
+      .map((item) => item.tag),
+  );
+
   let hasExactMatch = $derived(
     suggestions.some(
       (t) => t.name.toLowerCase() === query.trim().toLowerCase(),
@@ -77,7 +124,7 @@
   let showCreate = $derived(
     open && query.trim() && !hasExactMatch && !!onCreateTag,
   );
-  let totalOptions = $derived(suggestions.length + (showCreate ? 1 : 0));
+  let totalOptions = $derived(sortedSuggestions.length + (showCreate ? 1 : 0));
 
   function handleKeydown(e: KeyboardEvent) {
     if (!open && e.key !== "Escape") return;
@@ -95,9 +142,9 @@
         break;
       case "Enter":
         e.preventDefault();
-        if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
-          selectTag(suggestions[highlightIndex]);
-        } else if (showCreate && highlightIndex === suggestions.length) {
+        if (highlightIndex >= 0 && highlightIndex < sortedSuggestions.length) {
+          selectTag(sortedSuggestions[highlightIndex]);
+        } else if (showCreate && highlightIndex === sortedSuggestions.length) {
           createTag(query.trim());
         }
         break;
@@ -134,20 +181,26 @@
   {#if open && totalOptions > 0}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="tag-input-dropdown" onmousedown={(e) => e.preventDefault()}>
-      {#each suggestions as tag, i (tag.id)}
-        <button
-          class="tag-input-option"
-          class:tag-input-option-highlight={i === highlightIndex}
-          onmousedown={() => selectTag(tag)}
-        >
-          {tag.name}
-        </button>
+      {#each groupedItems as item (item.type === "header" ? `h:${item.category}` : `t:${item.tag.id}`)}
+        {#if item.type === "header"}
+          <div class="tag-input-category-header">
+            {item.category || "その他"}
+          </div>
+        {:else}
+          <button
+            class="tag-input-option"
+            class:tag-input-option-highlight={item.flatIndex === highlightIndex}
+            onmousedown={() => selectTag(item.tag)}
+          >
+            {item.tag.name}
+          </button>
+        {/if}
       {/each}
       {#if showCreate}
         <button
           class="tag-input-option tag-input-create"
           class:tag-input-option-highlight={highlightIndex ===
-            suggestions.length}
+            sortedSuggestions.length}
           onmousedown={() => createTag(query.trim())}
         >
           "{query.trim()}" を作成

--- a/src/lib/components/WorkGrid.svelte
+++ b/src/lib/components/WorkGrid.svelte
@@ -145,7 +145,7 @@
   </div>
   <div class="filter-section">
     {#each filterTags as tag (tag.id)}
-      <span class="tag-badge">
+      <span class="tag-badge" data-category={tag.category}>
         {tag.name}
         <button
           class="tag-badge-remove"

--- a/src/lib/components/WorkViewer.svelte
+++ b/src/lib/components/WorkViewer.svelte
@@ -35,6 +35,7 @@
   let intervalInputFocused = $state(false);
   let tagInputFocused = $state(false);
   let workTags = $state<Tag[]>([]);
+  let tagToRemove = $state<Tag | null>(null);
 
   let imageUrl = $derived(`sharaku://localhost/view/${workId}/${currentPage}`);
   let pageCount = $derived(work?.pageCount ?? 1);
@@ -206,6 +207,13 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
+    if (tagToRemove) {
+      if (e.key === "Escape") {
+        tagToRemove = null;
+        e.stopPropagation();
+      }
+      return;
+    }
     if ((intervalInputFocused || tagInputFocused) && e.key !== "Escape") return;
 
     switch (e.key) {
@@ -371,12 +379,9 @@
     onfocusout={() => (tagInputFocused = false)}
   >
     {#each workTags as tag (tag.id)}
-      <span class="tag-badge">
+      <span class="tag-badge" data-category={tag.category}>
         {tag.name}
-        <button
-          class="tag-badge-remove"
-          onclick={() => handleRemoveTag(tag.id)}
-        >
+        <button class="tag-badge-remove" onclick={() => (tagToRemove = tag)}>
           &times;
         </button>
       </span>
@@ -513,4 +518,37 @@
       </span>
     </div>
   </div>
+
+  {#if tagToRemove}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="tag-confirm-overlay"
+      onmousedown={(e) => {
+        if (e.target === e.currentTarget) tagToRemove = null;
+      }}
+    >
+      <div class="tag-confirm-dialog">
+        <p>タグ「{tagToRemove.name}」を削除しますか？</p>
+        <div class="tag-confirm-actions">
+          <button
+            class="tag-confirm-cancel"
+            onclick={() => (tagToRemove = null)}
+          >
+            キャンセル
+          </button>
+          <button
+            class="tag-confirm-delete"
+            onclick={() => {
+              if (tagToRemove) {
+                handleRemoveTag(tagToRemove.id);
+                tagToRemove = null;
+              }
+            }}
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/7

# 変更点

- タグバッジをカテゴリ（artist/circle/genre/series）ごとに色分け表示
- TagInput ドロップダウンの検索結果をカテゴリ別にグループ化し、ヘッダー付きで表示
- WorkViewer でタグ削除時に確認ダイアログを表示するように変更
- ダークモード・Viewer 暗背景での各カテゴリ色を調整

# 備考

- Phase 1（バックエンド）、Phase 2（フロントエンド基盤）で未対応だった受け入れ条件3項目を実装
- WorkGrid のフィルタタグ解除はDB操作ではないため確認ダイアログ不要