### PR TITLE
GitHub Actions リリースワークフロー追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:
@@ -14,11 +14,11 @@ jobs:
       matrix:
         include:
           - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
+            args: "--target aarch64-apple-darwin"
           - platform: ubuntu-22.04
-            args: ''
+            args: ""
           - platform: windows-latest
-            args: ''
+            args: ""
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -54,8 +54,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: v__VERSION__
-          releaseName: 'Sharaku v__VERSION__'
-          releaseBody: 'See the assets to download and install.'
+          releaseName: "Sharaku v__VERSION__"
+          releaseBody: "See the assets to download and install."
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
# 変更点

- タグ push（`v*`）時に macOS / Linux / Windows の3プラットフォーム分のバイナリをビルドする GitHub Actions ワークフローを追加
- `tauri-apps/tauri-action@v0` を使用し、ビルド成果物を GitHub Releases にドラフトリリースとしてアップロード
- `fail-fast: false` で1プラットフォームの失敗が他に影響しない構成

# 備考

- コード署名なしのため、macOS Gatekeeper / Windows SmartScreen で警告が出る（自分用なので許容）
- 既存の `ci.yml` には影響なし