### PR TITLE
CIFS/SMB上のライブラリでDB作成が失敗する問題を修正

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -21,7 +21,9 @@ pub fn init_db_for_test(conn: &Connection) -> Result<(), AppError> {
 }
 
 fn init_db(conn: &Connection) -> Result<(), AppError> {
-    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    // CIFS/SMB上ではWALモードの.db-shm(mmap)が動作しないためDELETEモードを採用。
+    // DB接続はArc<Mutex>で一元管理しておりWALの同時読み書き性能は不要。
+    conn.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=ON;")?;
     conn.execute_batch(include_str!("../migrations/001_create_initial_tables.sql"))?;
     apply_migration_002(conn)?;
     apply_migration_003(conn)?;


### PR DESCRIPTION
# 変更点

- SQLiteのジャーナルモードをWALからDELETEに変更
  - WALモードは `.db-shm` で mmap を使用するため、CIFS/SMBネットワーク共有上で動作しない
  - DB接続は `Arc<Mutex>` で一元管理されており、WALの同時読み書き性能は不要
- `busy_timeout(5s)` や `foreign_keys=ON` など他の設定は変更なし

# 備考

- 既存のWALモードDBはSQLiteが自動的にDELETEモードに移行し、WAL/SHMファイルをクリーンアップする
- DELETEモードもACID準拠でクラッシュ耐性あり