### PR TITLE
[#48] ライブラリ管理DBをローカル単一DBに統合

### DIFF
--- a/src-tauri/migrations/004_unified_local_db.sql
+++ b/src-tauri/migrations/004_unified_local_db.sql
@@ -1,0 +1,82 @@
+-- Migration 004: Unified local database
+-- All data is stored in a single DB in app_data_dir, keyed by library_id.
+
+CREATE TABLE IF NOT EXISTS libraries (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    path       TEXT NOT NULL UNIQUE,
+    is_active  INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS works (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id TEXT    NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    title      TEXT    NOT NULL,
+    path       TEXT    NOT NULL,
+    type       TEXT    NOT NULL CHECK (type IN ('image', 'pdf', 'archive', 'folder')),
+    page_count INTEGER,
+    thumbnail  BLOB,
+    created_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    artist     TEXT,
+    year       INTEGER,
+    genre      TEXT,
+    circle     TEXT,
+    origin     TEXT,
+    UNIQUE(library_id, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_works_library_id ON works(library_id);
+CREATE INDEX IF NOT EXISTS idx_works_type       ON works(type);
+CREATE INDEX IF NOT EXISTS idx_works_title      ON works(title);
+CREATE INDEX IF NOT EXISTS idx_works_created_at ON works(created_at);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    category   TEXT,
+    UNIQUE(library_id, name, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_library_id ON tags(library_id);
+CREATE INDEX IF NOT EXISTS idx_tags_category   ON tags(category);
+CREATE INDEX IF NOT EXISTS idx_tags_name       ON tags(name);
+
+CREATE TABLE IF NOT EXISTS works_tags (
+    work_id INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (work_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_works_tags_tag_id ON works_tags(tag_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+    library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    PRIMARY KEY (library_id, key)
+);
+
+CREATE TABLE IF NOT EXISTS playlists (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_playlists_library_id ON playlists(library_id);
+
+CREATE TABLE IF NOT EXISTS playlist_items (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+    work_id     INTEGER NOT NULL REFERENCES works(id)     ON DELETE CASCADE,
+    position    INTEGER NOT NULL,
+    UNIQUE(playlist_id, work_id),
+    UNIQUE(playlist_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_playlist_items_work_id  ON playlist_items(work_id);
+CREATE INDEX IF NOT EXISTS idx_playlist_items_position ON playlist_items(playlist_id, position);

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -6,9 +6,9 @@ use serde::Serialize;
 
 use crate::error::AppError;
 
-pub fn open_db(library_root: &Path) -> Result<Connection, AppError> {
-    std::fs::create_dir_all(library_root)?;
-    let db_path = library_root.join("sharaku.db");
+pub fn open_db(app_data_dir: &Path) -> Result<Connection, AppError> {
+    std::fs::create_dir_all(app_data_dir)?;
+    let db_path = app_data_dir.join("sharaku.db");
     let conn = Connection::open(db_path)?;
     conn.busy_timeout(std::time::Duration::from_secs(5))?;
     init_db(&conn)?;
@@ -16,59 +16,26 @@ pub fn open_db(library_root: &Path) -> Result<Connection, AppError> {
 }
 
 #[cfg(test)]
-pub fn init_db_for_test(conn: &Connection) -> Result<(), AppError> {
-    init_db(conn)
+pub fn open_db_in_memory() -> Result<Connection, AppError> {
+    let conn = Connection::open_in_memory()?;
+    init_db(&conn)?;
+    Ok(conn)
 }
 
 fn init_db(conn: &Connection) -> Result<(), AppError> {
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-    conn.execute_batch(include_str!("../migrations/001_create_initial_tables.sql"))?;
-    apply_migration_002(conn)?;
-    apply_migration_003(conn)?;
+    conn.execute_batch(include_str!("../migrations/004_unified_local_db.sql"))?;
     Ok(())
 }
 
-fn apply_migration_002(conn: &Connection) -> Result<(), AppError> {
-    let columns = ["artist", "year", "genre", "circle", "origin"];
-    for col in columns {
-        let sql = match col {
-            "year" => format!("ALTER TABLE works ADD COLUMN {col} INTEGER"),
-            _ => format!("ALTER TABLE works ADD COLUMN {col} TEXT"),
-        };
-        match conn.execute_batch(&sql) {
-            Ok(()) => {}
-            Err(e) if e.to_string().contains("duplicate column name") => {}
-            Err(e) => return Err(AppError::Database(e)),
-        }
-    }
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
-    )?;
-    Ok(())
-}
-
-fn apply_migration_003(conn: &Connection) -> Result<(), AppError> {
-    let needs_migration = match conn.query_row(
-        "SELECT sql FROM sqlite_master WHERE type='table' AND name='works'",
-        [],
-        |row| row.get::<_, String>(0),
-    ) {
-        Ok(sql) => !sql.contains("folder"),
-        Err(e) => return Err(AppError::Database(e)),
-    };
-
-    if needs_migration {
-        conn.execute_batch(include_str!("../migrations/003_allow_folder_work_type.sql"))?;
-    }
-    Ok(())
-}
-
-pub fn path_exists(conn: &Connection, path: &str) -> Result<bool, AppError> {
-    let mut stmt = conn.prepare_cached("SELECT 1 FROM works WHERE path = ?1")?;
-    Ok(stmt.exists([path])?)
+pub fn path_exists(conn: &Connection, library_id: &str, path: &str) -> Result<bool, AppError> {
+    let mut stmt =
+        conn.prepare_cached("SELECT 1 FROM works WHERE library_id = ?1 AND path = ?2")?;
+    Ok(stmt.exists(rusqlite::params![library_id, path])?)
 }
 
 pub struct WorkRecord<'a> {
+    pub library_id: &'a str,
     pub title: &'a str,
     pub path: &'a str,
     pub work_type: &'a str,
@@ -83,8 +50,9 @@ pub struct WorkRecord<'a> {
 
 pub fn insert_work(conn: &Connection, record: &WorkRecord) -> Result<(), AppError> {
     conn.execute(
-        "INSERT INTO works (title, path, type, page_count, thumbnail, artist, year, genre, circle, origin) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO works (library_id, title, path, type, page_count, thumbnail, artist, year, genre, circle, origin) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         rusqlite::params![
+            record.library_id,
             record.title,
             record.path,
             record.work_type,
@@ -136,6 +104,7 @@ pub struct WorkDetail {
 
 pub fn list_works(
     conn: &Connection,
+    library_id: &str,
     sort_by: &str,
     sort_order: &str,
 ) -> Result<Vec<WorkSummary>, AppError> {
@@ -148,11 +117,11 @@ pub fn list_works(
         _ => "DESC",
     };
     let sql = format!(
-        "SELECT id, title, type, page_count, created_at FROM works ORDER BY {} {}",
+        "SELECT id, title, type, page_count, created_at FROM works WHERE library_id = ?1 ORDER BY {} {}",
         column, order
     );
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
+    let rows = stmt.query_map([library_id], |row| {
         Ok(WorkSummary {
             id: row.get(0)?,
             title: row.get(1)?,
@@ -179,11 +148,11 @@ pub fn get_thumbnail(conn: &Connection, work_id: i64) -> Result<Vec<u8>, AppErro
     thumb.ok_or(AppError::NotFound)
 }
 
-pub fn list_folder_works(conn: &Connection) -> Result<Vec<WorkDetail>, AppError> {
+pub fn list_folder_works(conn: &Connection, library_id: &str) -> Result<Vec<WorkDetail>, AppError> {
     let mut stmt = conn.prepare_cached(
-        "SELECT id, title, path, type, page_count, created_at, artist, year, genre, circle, origin FROM works WHERE type = 'folder'",
+        "SELECT id, title, path, type, page_count, created_at, artist, year, genre, circle, origin FROM works WHERE library_id = ?1 AND type = 'folder'",
     )?;
-    let rows = stmt.query_map([], |row| {
+    let rows = stmt.query_map([library_id], |row| {
         Ok(WorkDetail {
             id: row.get(0)?,
             title: row.get(1)?,
@@ -238,10 +207,15 @@ pub fn get_work(conn: &Connection, work_id: i64) -> Result<WorkDetail, AppError>
     })
 }
 
-pub fn create_tag(conn: &Connection, name: &str, category: Option<&str>) -> Result<Tag, AppError> {
+pub fn create_tag(
+    conn: &Connection,
+    library_id: &str,
+    name: &str,
+    category: Option<&str>,
+) -> Result<Tag, AppError> {
     conn.execute(
-        "INSERT INTO tags (name, category) VALUES (?1, ?2)",
-        rusqlite::params![name, category],
+        "INSERT INTO tags (library_id, name, category) VALUES (?1, ?2, ?3)",
+        rusqlite::params![library_id, name, category],
     )?;
     Ok(Tag {
         id: conn.last_insert_rowid(),
@@ -276,14 +250,15 @@ pub fn delete_tag(conn: &Connection, id: i64) -> Result<(), AppError> {
 
 pub fn search_tags(
     conn: &Connection,
+    library_id: &str,
     query: &str,
     category: Option<&str>,
 ) -> Result<Vec<Tag>, AppError> {
     let pattern = format!("%{query}%");
     let mut stmt = conn.prepare(
-        "SELECT id, name, category FROM tags WHERE name LIKE ?1 AND (?2 IS NULL OR category = ?2) ORDER BY name LIMIT 50",
+        "SELECT id, name, category FROM tags WHERE library_id = ?1 AND name LIKE ?2 AND (?3 IS NULL OR category = ?3) ORDER BY name LIMIT 50",
     )?;
-    let rows = stmt.query_map(rusqlite::params![pattern, category], |row| {
+    let rows = stmt.query_map(rusqlite::params![library_id, pattern, category], |row| {
         Ok(Tag {
             id: row.get(0)?,
             name: row.get(1)?,
@@ -333,6 +308,7 @@ pub fn get_tags_for_work(conn: &Connection, work_id: i64) -> Result<Vec<Tag>, Ap
 
 pub fn search_works_by_tags(
     conn: &Connection,
+    library_id: &str,
     tag_ids: &[i64],
     mode: &str,
 ) -> Result<Vec<WorkSummary>, AppError> {
@@ -344,7 +320,10 @@ pub fn search_works_by_tags(
     unique_ids.sort_unstable();
     unique_ids.dedup();
 
-    let placeholders: Vec<String> = (1..=unique_ids.len()).map(|i| format!("?{i}")).collect();
+    // Parameter index: ?1 = library_id, then tag IDs start at ?2
+    let placeholders: Vec<String> = (2..=unique_ids.len() + 1)
+        .map(|i| format!("?{i}"))
+        .collect();
     let in_clause = placeholders.join(", ");
 
     let sql = if mode == "and" {
@@ -352,24 +331,27 @@ pub fn search_works_by_tags(
             "SELECT w.id, w.title, w.type, w.page_count, w.created_at \
              FROM works w \
              INNER JOIN works_tags wt ON w.id = wt.work_id \
-             WHERE wt.tag_id IN ({in_clause}) \
+             WHERE w.library_id = ?1 AND wt.tag_id IN ({in_clause}) \
              GROUP BY w.id \
              HAVING COUNT(DISTINCT wt.tag_id) = ?{} \
              ORDER BY w.created_at DESC",
-            unique_ids.len() + 1
+            unique_ids.len() + 2
         )
     } else {
         format!(
             "SELECT DISTINCT w.id, w.title, w.type, w.page_count, w.created_at \
              FROM works w \
              INNER JOIN works_tags wt ON w.id = wt.work_id \
-             WHERE wt.tag_id IN ({in_clause}) \
+             WHERE w.library_id = ?1 AND wt.tag_id IN ({in_clause}) \
              ORDER BY w.created_at DESC"
         )
     };
 
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
-        unique_ids.iter().map(|id| Box::new(*id) as _).collect();
+        vec![Box::new(library_id.to_string()) as _];
+    for id in &unique_ids {
+        params.push(Box::new(*id) as _);
+    }
     if mode == "and" {
         params.push(Box::new(unique_ids.len() as i64));
     }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -104,6 +104,7 @@ pub fn preview_import_path(
 pub fn import_work(
     request: &ImportRequest,
     conn: &rusqlite::Connection,
+    library_id: &str,
     library_root: &Path,
 ) -> Result<ImportResult, AppError> {
     let source = Path::new(&request.source_path);
@@ -120,11 +121,11 @@ pub fn import_work(
         ));
     }
 
-    let template_str = settings::get_directory_template(conn)?.ok_or_else(|| {
+    let template_str = settings::get_directory_template(conn, library_id)?.ok_or_else(|| {
         AppError::ImportError("ディレクトリテンプレートが設定されていません".to_string())
     })?;
 
-    let type_label = settings::resolve_type_label(conn, "folder")?;
+    let type_label = settings::resolve_type_label(conn, library_id, "folder")?;
     let metadata = WorkMetadata {
         title: request.title.clone(),
         artist: request.artist.clone(),
@@ -151,7 +152,6 @@ pub fn import_work(
         let _ = std::fs::remove_dir_all(dest);
     };
 
-    // Always copy first (even in Move mode) to avoid data loss on failure
     if let Err(e) = copy_images_to_dest(&images, &dest) {
         rollback(&dest);
         return Err(e);
@@ -163,6 +163,7 @@ pub fn import_work(
     if let Err(e) = db::insert_work(
         conn,
         &WorkRecord {
+            library_id,
             title: &request.title,
             path: &dest_str,
             work_type: "folder",
@@ -179,7 +180,6 @@ pub fn import_work(
         return Err(e);
     }
 
-    // Delete source files only after successful DB registration
     if request.mode == ImportMode::Move {
         for image in &images {
             let _ = std::fs::remove_file(image);
@@ -228,6 +228,7 @@ pub enum DiscoverProgress {
 pub fn discover_image_folders(
     root: &Path,
     conn: &rusqlite::Connection,
+    library_id: &str,
     on_progress: &Channel<DiscoverProgress>,
 ) -> Result<Vec<DiscoveredFolder>, AppError> {
     let mut folders = Vec::new();
@@ -256,7 +257,7 @@ pub fn discover_image_folders(
             .to_string();
 
         let path_str = dir_path.to_string_lossy().to_string();
-        let already_registered = db::path_exists(conn, &path_str)?;
+        let already_registered = db::path_exists(conn, library_id, &path_str)?;
         let parsed_metadata = parse_folder_name(&folder_name);
 
         folders.push(DiscoveredFolder {
@@ -320,6 +321,7 @@ pub struct BulkImportSummary {
 pub fn bulk_import(
     requests: &[ImportRequest],
     conn: &rusqlite::Connection,
+    library_id: &str,
     library_root: &Path,
     on_progress: &Channel<BulkImportProgress>,
 ) -> Result<BulkImportSummary, AppError> {
@@ -336,7 +338,7 @@ pub fn bulk_import(
             title: request.title.clone(),
         });
 
-        match import_work(request, conn, library_root) {
+        match import_work(request, conn, library_id, library_root) {
             Ok(_) => succeeded += 1,
             Err(e) => {
                 let _ = on_progress.send(BulkImportProgress::Error {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,24 +26,27 @@ use serde::Serialize;
 use template::WorkMetadata;
 
 struct ActiveLibrary {
+    id: String,
     path: PathBuf,
+}
+
+struct AppDb {
     conn: Connection,
+    active_library: Option<ActiveLibrary>,
 }
 
 pub struct AppState {
-    app_data_dir: PathBuf,
-    active_library: Arc<Mutex<Option<ActiveLibrary>>>,
+    db: Arc<Mutex<AppDb>>,
 }
 
 // --- Library CRUD commands ---
 
 #[tauri::command]
 async fn list_libraries(state: tauri::State<'_, AppState>) -> Result<Vec<Library>, String> {
-    let app_data_dir = state.app_data_dir.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
-        let store = library::LibraryStore::new(&app_data_dir);
-        let (libraries, _) = store.load().map_err(|e| e.to_string())?;
-        Ok(libraries)
+        let guard = db.lock().unwrap();
+        library::list_libraries(&guard.conn).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -51,10 +54,10 @@ async fn list_libraries(state: tauri::State<'_, AppState>) -> Result<Vec<Library
 
 #[tauri::command]
 async fn get_active_library(state: tauri::State<'_, AppState>) -> Result<Option<Library>, String> {
-    let app_data_dir = state.app_data_dir.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
-        let store = library::LibraryStore::new(&app_data_dir);
-        store.active_library().map_err(|e| e.to_string())
+        let guard = db.lock().unwrap();
+        library::active_library(&guard.conn).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -66,26 +69,16 @@ async fn create_library(
     name: String,
     path: String,
 ) -> Result<Library, String> {
-    let app_data_dir = state.app_data_dir.clone();
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
-        let store = library::LibraryStore::new(&app_data_dir);
-        let lib = store.add(&name, &path).map_err(|e| e.to_string())?;
-        let library_root = PathBuf::from(&lib.path);
-        match db::open_db(&library_root) {
-            Ok(conn) => {
-                store.set_active(&lib.id).map_err(|e| e.to_string())?;
-                *db.lock().unwrap() = Some(ActiveLibrary {
-                    path: library_root,
-                    conn,
-                });
-                Ok(lib)
-            }
-            Err(e) => {
-                let _ = store.remove(&lib.id);
-                Err(e.to_string())
-            }
-        }
+        let mut guard = db.lock().unwrap();
+        let lib = library::add_library(&guard.conn, &name, &path).map_err(|e| e.to_string())?;
+        library::set_active_library(&guard.conn, &lib.id).map_err(|e| e.to_string())?;
+        guard.active_library = Some(ActiveLibrary {
+            id: lib.id.clone(),
+            path: PathBuf::from(&lib.path),
+        });
+        Ok(lib)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -93,20 +86,16 @@ async fn create_library(
 
 #[tauri::command]
 async fn switch_library(state: tauri::State<'_, AppState>, id: String) -> Result<(), String> {
-    let app_data_dir = state.app_data_dir.clone();
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
-        let store = library::LibraryStore::new(&app_data_dir);
-        let lib = store
-            .find_by_id(&id)
+        let mut guard = db.lock().unwrap();
+        let lib = library::find_library_by_id(&guard.conn, &id)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| "ライブラリが見つかりません".to_string())?;
-        let library_root = PathBuf::from(&lib.path);
-        let conn = db::open_db(&library_root).map_err(|e| e.to_string())?;
-        store.set_active(&id).map_err(|e| e.to_string())?;
-        *db.lock().unwrap() = Some(ActiveLibrary {
-            path: library_root,
-            conn,
+        library::set_active_library(&guard.conn, &id).map_err(|e| e.to_string())?;
+        guard.active_library = Some(ActiveLibrary {
+            id: lib.id,
+            path: PathBuf::from(&lib.path),
         });
         Ok(())
     })
@@ -116,30 +105,22 @@ async fn switch_library(state: tauri::State<'_, AppState>, id: String) -> Result
 
 #[tauri::command]
 async fn remove_library(state: tauri::State<'_, AppState>, id: String) -> Result<(), String> {
-    let app_data_dir = state.app_data_dir.clone();
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
-        let store = library::LibraryStore::new(&app_data_dir);
-        store.remove(&id).map_err(|e| e.to_string())?;
-        let active = store.active_library().map_err(|e| e.to_string())?;
-        let new_active = match active {
-            Some(lib) => {
-                let library_root = PathBuf::from(&lib.path);
-                db::open_db(&library_root).ok().map(|conn| ActiveLibrary {
-                    path: library_root,
-                    conn,
-                })
-            }
-            None => None,
-        };
-        *db.lock().unwrap() = new_active;
+        let mut guard = db.lock().unwrap();
+        library::remove_library(&guard.conn, &id).map_err(|e| e.to_string())?;
+        let active = library::active_library(&guard.conn).map_err(|e| e.to_string())?;
+        guard.active_library = active.map(|lib| ActiveLibrary {
+            id: lib.id,
+            path: PathBuf::from(&lib.path),
+        });
         Ok(())
     })
     .await
     .map_err(|e| e.to_string())?
 }
 
-// --- Existing commands (migrated to AppState) ---
+// --- Existing commands (migrated to unified DB) ---
 
 #[tauri::command]
 async fn list_works(
@@ -147,11 +128,14 @@ async fn list_works(
     sort_by: String,
     sort_order: String,
 ) -> Result<Vec<WorkSummary>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::list_works(&lib.conn, &sort_by, &sort_order).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::list_works(&guard.conn, &active.id, &sort_by, &sort_order).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -159,11 +143,14 @@ async fn list_works(
 
 #[tauri::command]
 async fn get_thumbnail(state: tauri::State<'_, AppState>, work_id: i64) -> Result<Vec<u8>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::get_thumbnail(&lib.conn, work_id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::get_thumbnail(&guard.conn, work_id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -171,11 +158,14 @@ async fn get_thumbnail(state: tauri::State<'_, AppState>, work_id: i64) -> Resul
 
 #[tauri::command]
 async fn get_work(state: tauri::State<'_, AppState>, work_id: i64) -> Result<WorkDetail, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::get_work(&lib.conn, work_id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::get_work(&guard.conn, work_id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -191,16 +181,19 @@ struct AppSettings {
 
 #[tauri::command]
 async fn get_settings(state: tauri::State<'_, AppState>) -> Result<AppSettings, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
         let directory_template =
-            settings::get_directory_template(&lib.conn).map_err(|e| e.to_string())?;
+            settings::get_directory_template(&guard.conn, &active.id).map_err(|e| e.to_string())?;
         let type_label_image =
-            settings::get_type_label_image(&lib.conn).map_err(|e| e.to_string())?;
+            settings::get_type_label_image(&guard.conn, &active.id).map_err(|e| e.to_string())?;
         let type_label_folder =
-            settings::get_type_label_folder(&lib.conn).map_err(|e| e.to_string())?;
+            settings::get_type_label_folder(&guard.conn, &active.id).map_err(|e| e.to_string())?;
         Ok(AppSettings {
             directory_template,
             type_label_image,
@@ -220,11 +213,15 @@ async fn set_directory_template(
     if !trimmed.is_empty() {
         template::validate_template(&trimmed).map_err(|e| e.to_string())?;
     }
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        settings::set_directory_template(&lib.conn, &trimmed).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        settings::set_directory_template(&guard.conn, &active.id, &trimmed)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -246,12 +243,17 @@ async fn set_type_labels(
     if image_label.is_empty() || folder_label.is_empty() {
         return Err("ラベルは空にできません".to_string());
     }
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        settings::set_type_label_image(&lib.conn, &image_label).map_err(|e| e.to_string())?;
-        settings::set_type_label_folder(&lib.conn, &folder_label).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        settings::set_type_label_image(&guard.conn, &active.id, &image_label)
+            .map_err(|e| e.to_string())?;
+        settings::set_type_label_folder(&guard.conn, &active.id, &folder_label)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -263,11 +265,15 @@ async fn preview_template(
     template: String,
 ) -> Result<String, String> {
     template::validate_template(&template).map_err(|e| e.to_string())?;
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        let folder_label = settings::get_type_label_folder(&lib.conn).map_err(|e| e.to_string())?;
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        let folder_label =
+            settings::get_type_label_folder(&guard.conn, &active.id).map_err(|e| e.to_string())?;
         let mut metadata = template::sample_metadata();
         metadata.work_type = Some(folder_label);
         Ok(template::render_template(&template, &metadata))
@@ -286,15 +292,18 @@ async fn preview_import_path(
     state: tauri::State<'_, AppState>,
     metadata: WorkMetadata,
 ) -> Result<String, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        let template_str = settings::get_directory_template(&lib.conn)
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        let template_str = settings::get_directory_template(&guard.conn, &active.id)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| "ディレクトリテンプレートが設定されていません".to_string())?;
         Ok(importer::preview_import_path(
-            &lib.path,
+            &active.path,
             &template_str,
             &metadata,
         ))
@@ -308,11 +317,15 @@ async fn import_work(
     state: tauri::State<'_, AppState>,
     request: importer::ImportRequest,
 ) -> Result<ImportResult, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        importer::import_work(&request, &lib.conn, &lib.path).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        importer::import_work(&request, &guard.conn, &active.id, &active.path)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -324,12 +337,16 @@ async fn discover_folders(
     root_path: String,
     on_progress: tauri::ipc::Channel<DiscoverProgress>,
 ) -> Result<Vec<DiscoveredFolder>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     let root = PathBuf::from(root_path);
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        importer::discover_image_folders(&root, &lib.conn, &on_progress).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        importer::discover_image_folders(&root, &guard.conn, &active.id, &on_progress)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -341,12 +358,21 @@ async fn bulk_import(
     requests: Vec<importer::ImportRequest>,
     on_progress: tauri::ipc::Channel<BulkImportProgress>,
 ) -> Result<BulkImportSummary, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        importer::bulk_import(&requests, &lib.conn, &lib.path, &on_progress)
-            .map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        importer::bulk_import(
+            &requests,
+            &guard.conn,
+            &active.id,
+            &active.path,
+            &on_progress,
+        )
+        .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -359,11 +385,15 @@ async fn preview_relocation(
 ) -> Result<Vec<RelocationPreview>, String> {
     let trimmed = new_template.trim().to_string();
     template::validate_template(&trimmed).map_err(|e| e.to_string())?;
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        relocator::preview_relocation(&lib.conn, &lib.path, &trimmed).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        relocator::preview_relocation(&guard.conn, &active.id, &active.path, &trimmed)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -377,12 +407,21 @@ async fn relocate_works(
 ) -> Result<(), String> {
     let trimmed = new_template.trim().to_string();
     template::validate_template(&trimmed).map_err(|e| e.to_string())?;
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        relocator::execute_relocation(&lib.conn, &lib.path, &trimmed, &on_progress)
-            .map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        relocator::execute_relocation(
+            &guard.conn,
+            &active.id,
+            &active.path,
+            &trimmed,
+            &on_progress,
+        )
+        .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -394,11 +433,15 @@ async fn search_tags(
     query: String,
     category: Option<String>,
 ) -> Result<Vec<Tag>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::search_tags(&lib.conn, &query, category.as_deref()).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::search_tags(&guard.conn, &active.id, &query, category.as_deref())
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -410,11 +453,15 @@ async fn create_tag(
     name: String,
     category: Option<String>,
 ) -> Result<Tag, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::create_tag(&lib.conn, &name, category.as_deref()).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::create_tag(&guard.conn, &active.id, &name, category.as_deref())
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -427,11 +474,14 @@ async fn update_tag(
     name: String,
     category: Option<String>,
 ) -> Result<(), String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::update_tag(&lib.conn, id, &name, category.as_deref()).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::update_tag(&guard.conn, id, &name, category.as_deref()).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -439,11 +489,14 @@ async fn update_tag(
 
 #[tauri::command]
 async fn delete_tag(state: tauri::State<'_, AppState>, id: i64) -> Result<(), String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::delete_tag(&lib.conn, id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::delete_tag(&guard.conn, id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -455,11 +508,14 @@ async fn add_tag_to_work(
     work_id: i64,
     tag_id: i64,
 ) -> Result<(), String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::add_tag_to_work(&lib.conn, work_id, tag_id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::add_tag_to_work(&guard.conn, work_id, tag_id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -471,11 +527,14 @@ async fn remove_tag_from_work(
     work_id: i64,
     tag_id: i64,
 ) -> Result<(), String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::remove_tag_from_work(&lib.conn, work_id, tag_id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::remove_tag_from_work(&guard.conn, work_id, tag_id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -486,11 +545,14 @@ async fn get_tags_for_work(
     state: tauri::State<'_, AppState>,
     work_id: i64,
 ) -> Result<Vec<Tag>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::get_tags_for_work(&lib.conn, work_id).map_err(|e| e.to_string())
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::get_tags_for_work(&guard.conn, work_id).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -502,14 +564,64 @@ async fn search_works_by_tags(
     tag_ids: Vec<i64>,
     mode: String,
 ) -> Result<Vec<WorkSummary>, String> {
-    let db = state.active_library.clone();
+    let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
-        let lib = guard.as_ref().ok_or("ライブラリが選択されていません")?;
-        db::search_works_by_tags(&lib.conn, &tag_ids, &mode).map_err(|e| e.to_string())
+        let active = guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::search_works_by_tags(&guard.conn, &active.id, &tag_ids, &mode)
+            .map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+fn migrate_libraries_json(conn: &Connection, app_data_dir: &std::path::Path) {
+    let json_path = app_data_dir.join("libraries.json");
+    if !json_path.exists() {
+        return;
+    }
+
+    #[derive(serde::Deserialize)]
+    struct LibraryStoreData {
+        libraries: Vec<JsonLibrary>,
+        active_library_id: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct JsonLibrary {
+        id: String,
+        name: String,
+        path: String,
+    }
+
+    let content = match std::fs::read_to_string(&json_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let data: LibraryStoreData = match serde_json::from_str(&content) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    for lib in &data.libraries {
+        let already_exists: bool = conn
+            .prepare_cached("SELECT 1 FROM libraries WHERE id = ?1")
+            .and_then(|mut stmt| stmt.exists([&lib.id]))
+            .unwrap_or(true);
+        if already_exists {
+            continue;
+        }
+        let is_active = data.active_library_id.as_deref() == Some(&lib.id);
+        let _ = conn.execute(
+            "INSERT INTO libraries (id, name, path, is_active) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![lib.id, lib.name, lib.path, is_active as i32],
+        );
+    }
+
+    let migrated_path = json_path.with_extension("json.migrated");
+    let _ = std::fs::rename(&json_path, &migrated_path);
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -521,17 +633,23 @@ pub fn run() {
         .setup(|app| {
             let app_data_dir = app.path().app_data_dir()?;
 
-            let store = library::LibraryStore::new(&app_data_dir);
-            let active_library = store.active_library().ok().flatten().and_then(|lib| {
-                let path = PathBuf::from(&lib.path);
-                db::open_db(&path)
+            let conn = db::open_db(&app_data_dir).expect("Failed to open database");
+            migrate_libraries_json(&conn, &app_data_dir);
+
+            let active_library =
+                library::active_library(&conn)
                     .ok()
-                    .map(|conn| ActiveLibrary { path, conn })
-            });
+                    .flatten()
+                    .map(|lib| ActiveLibrary {
+                        id: lib.id,
+                        path: PathBuf::from(&lib.path),
+                    });
 
             app.manage(AppState {
-                app_data_dir,
-                active_library: Arc::new(Mutex::new(active_library)),
+                db: Arc::new(Mutex::new(AppDb {
+                    conn,
+                    active_library,
+                })),
             });
 
             Ok(())
@@ -541,9 +659,9 @@ pub fn run() {
             match viewer::parse_view_uri(&uri) {
                 Some((work_id, page_index)) => {
                     let state = ctx.app_handle().state::<AppState>();
-                    let guard = state.active_library.lock().unwrap();
-                    match guard.as_ref() {
-                        Some(lib) => viewer::handle_view_request(&lib.conn, work_id, page_index),
+                    let guard = state.db.lock().unwrap();
+                    match guard.active_library.as_ref() {
+                        Some(_) => viewer::handle_view_request(&guard.conn, work_id, page_index),
                         None => tauri::http::Response::builder()
                             .status(500)
                             .body(Vec::new())

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -1,6 +1,6 @@
-use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
@@ -12,114 +12,121 @@ pub struct Library {
     pub path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct LibraryStoreData {
-    libraries: Vec<Library>,
-    active_library_id: Option<String>,
+pub fn list_libraries(conn: &Connection) -> Result<Vec<Library>, AppError> {
+    let mut stmt = conn.prepare_cached("SELECT id, name, path FROM libraries ORDER BY rowid")?;
+    let rows = stmt.query_map([], |row| {
+        Ok(Library {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            path: row.get(2)?,
+        })
+    })?;
+    let mut libs = Vec::new();
+    for row in rows {
+        libs.push(row?);
+    }
+    Ok(libs)
 }
 
-pub struct LibraryStore {
-    file_path: PathBuf,
+pub fn add_library(conn: &Connection, name: &str, path: &str) -> Result<Library, AppError> {
+    let existing: bool = conn
+        .prepare_cached("SELECT 1 FROM libraries WHERE path = ?1")?
+        .exists([path])?;
+    if existing {
+        return Err(AppError::LibraryError(
+            "同じパスのライブラリが既に存在します".to_string(),
+        ));
+    }
+
+    let id = generate_id();
+    conn.execute(
+        "INSERT INTO libraries (id, name, path) VALUES (?1, ?2, ?3)",
+        rusqlite::params![id, name, path],
+    )?;
+
+    let has_active: bool = conn
+        .prepare_cached("SELECT 1 FROM libraries WHERE is_active = 1")?
+        .exists([])?;
+    if !has_active {
+        conn.execute("UPDATE libraries SET is_active = 1 WHERE id = ?1", [&id])?;
+    }
+
+    Ok(Library {
+        id,
+        name: name.to_string(),
+        path: path.to_string(),
+    })
 }
 
-impl LibraryStore {
-    pub fn new(app_data_dir: &Path) -> Self {
-        Self {
-            file_path: app_data_dir.join("libraries.json"),
-        }
+pub fn remove_library(conn: &Connection, id: &str) -> Result<(), AppError> {
+    let was_active: bool = conn
+        .prepare_cached("SELECT is_active FROM libraries WHERE id = ?1")?
+        .query_row([id], |row| row.get(0))
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::LibraryError("指定されたライブラリが見つかりません".to_string())
+            }
+            other => AppError::Database(other),
+        })?;
+
+    conn.execute("DELETE FROM libraries WHERE id = ?1", [id])?;
+
+    if was_active {
+        conn.execute_batch(
+            "UPDATE libraries SET is_active = 1 WHERE rowid = (SELECT MIN(rowid) FROM libraries)",
+        )?;
     }
 
-    pub fn load(&self) -> Result<(Vec<Library>, Option<String>), AppError> {
-        if !self.file_path.exists() {
-            return Ok((Vec::new(), None));
-        }
-        let content = std::fs::read_to_string(&self.file_path)?;
-        let data: LibraryStoreData = serde_json::from_str(&content)?;
-        Ok((data.libraries, data.active_library_id))
+    Ok(())
+}
+
+pub fn find_library_by_id(conn: &Connection, id: &str) -> Result<Option<Library>, AppError> {
+    let mut stmt = conn.prepare_cached("SELECT id, name, path FROM libraries WHERE id = ?1")?;
+    let result = stmt
+        .query_row([id], |row| {
+            Ok(Library {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                path: row.get(2)?,
+            })
+        })
+        .optional();
+    match result {
+        Ok(lib) => Ok(lib),
+        Err(e) => Err(AppError::Database(e)),
     }
+}
 
-    fn save(&self, libraries: &[Library], active_id: Option<&str>) -> Result<(), AppError> {
-        let data = LibraryStoreData {
-            libraries: libraries.to_vec(),
-            active_library_id: active_id.map(|s| s.to_string()),
-        };
-        let content = serde_json::to_string_pretty(&data)?;
-        if let Some(parent) = self.file_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&self.file_path, content)?;
-        Ok(())
+pub fn active_library(conn: &Connection) -> Result<Option<Library>, AppError> {
+    let mut stmt =
+        conn.prepare_cached("SELECT id, name, path FROM libraries WHERE is_active = 1 LIMIT 1")?;
+    let result = stmt
+        .query_row([], |row| {
+            Ok(Library {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                path: row.get(2)?,
+            })
+        })
+        .optional();
+    match result {
+        Ok(lib) => Ok(lib),
+        Err(e) => Err(AppError::Database(e)),
     }
+}
 
-    pub fn add(&self, name: &str, path: &str) -> Result<Library, AppError> {
-        let (mut libraries, active_id) = self.load()?;
-
-        if libraries.iter().any(|lib| lib.path == path) {
-            return Err(AppError::LibraryError(
-                "同じパスのライブラリが既に存在します".to_string(),
-            ));
-        }
-
-        let id = generate_id();
-        let library = Library {
-            id: id.clone(),
-            name: name.to_string(),
-            path: path.to_string(),
-        };
-        libraries.push(library.clone());
-
-        let new_active = if active_id.is_some() {
-            active_id.as_deref()
-        } else {
-            Some(id.as_str())
-        };
-        self.save(&libraries, new_active)?;
-        Ok(library)
+pub fn set_active_library(conn: &Connection, id: &str) -> Result<(), AppError> {
+    let exists: bool = conn
+        .prepare_cached("SELECT 1 FROM libraries WHERE id = ?1")?
+        .exists([id])?;
+    if !exists {
+        return Err(AppError::LibraryError(
+            "指定されたライブラリが見つかりません".to_string(),
+        ));
     }
-
-    pub fn remove(&self, id: &str) -> Result<(), AppError> {
-        let (mut libraries, active_id) = self.load()?;
-        let original_len = libraries.len();
-        libraries.retain(|lib| lib.id != id);
-        if libraries.len() == original_len {
-            return Err(AppError::LibraryError(
-                "指定されたライブラリが見つかりません".to_string(),
-            ));
-        }
-
-        let new_active = if active_id.as_deref() == Some(id) {
-            libraries.first().map(|lib| lib.id.as_str())
-        } else {
-            active_id.as_deref()
-        };
-        self.save(&libraries, new_active)?;
-        Ok(())
-    }
-
-    pub fn set_active(&self, id: &str) -> Result<(), AppError> {
-        let (libraries, _) = self.load()?;
-        if !libraries.iter().any(|lib| lib.id == id) {
-            return Err(AppError::LibraryError(
-                "指定されたライブラリが見つかりません".to_string(),
-            ));
-        }
-        self.save(&libraries, Some(id))?;
-        Ok(())
-    }
-
-    pub fn find_by_id(&self, id: &str) -> Result<Option<Library>, AppError> {
-        let (libraries, _) = self.load()?;
-        Ok(libraries.into_iter().find(|lib| lib.id == id))
-    }
-
-    pub fn active_library(&self) -> Result<Option<Library>, AppError> {
-        let (libraries, active_id) = self.load()?;
-        let active_id = match active_id {
-            Some(id) => id,
-            None => return Ok(None),
-        };
-        Ok(libraries.into_iter().find(|lib| lib.id == active_id))
-    }
+    conn.execute("UPDATE libraries SET is_active = 0 WHERE is_active = 1", [])?;
+    conn.execute("UPDATE libraries SET is_active = 1 WHERE id = ?1", [id])?;
+    Ok(())
 }
 
 fn generate_id() -> String {
@@ -129,6 +136,8 @@ fn generate_id() -> String {
     let nanos = duration.as_nanos();
     format!("{:016x}", nanos & 0xFFFFFFFFFFFFFFFF)
 }
+
+use rusqlite::OptionalExtension;
 
 #[cfg(test)]
 #[path = "tests/library.rs"]

--- a/src-tauri/src/relocator.rs
+++ b/src-tauri/src/relocator.rs
@@ -102,11 +102,12 @@ fn make_unique_path(base: &Path, used_paths: &std::collections::HashSet<String>)
 
 pub fn preview_relocation(
     conn: &rusqlite::Connection,
+    library_id: &str,
     library_root: &Path,
     new_template: &str,
 ) -> Result<Vec<RelocationPreview>, AppError> {
-    let works = db::list_folder_works(conn)?;
-    let type_label = settings::get_type_label_folder(conn)?;
+    let works = db::list_folder_works(conn, library_id)?;
+    let type_label = settings::get_type_label_folder(conn, library_id)?;
     Ok(compute_relocation_plan(
         &works,
         library_root,
@@ -117,12 +118,13 @@ pub fn preview_relocation(
 
 pub fn execute_relocation(
     conn: &rusqlite::Connection,
+    library_id: &str,
     library_root: &Path,
     new_template: &str,
     on_progress: &Channel<RelocationProgress>,
 ) -> Result<(), AppError> {
-    let works = db::list_folder_works(conn)?;
-    let type_label = settings::get_type_label_folder(conn)?;
+    let works = db::list_folder_works(conn, library_id)?;
+    let type_label = settings::get_type_label_folder(conn, library_id)?;
     let plan = compute_relocation_plan(&works, library_root, new_template, &type_label);
 
     let total = plan.len();
@@ -171,7 +173,7 @@ pub fn execute_relocation(
         }
     }
 
-    settings::set_directory_template(conn, new_template)?;
+    settings::set_directory_template(conn, library_id, new_template)?;
 
     let _ = on_progress.send(RelocationProgress::Completed {
         relocated,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -2,19 +2,29 @@ use rusqlite::{Connection, OptionalExtension};
 
 use crate::error::AppError;
 
-pub fn get_setting(conn: &Connection, key: &str) -> Result<Option<String>, AppError> {
-    let mut stmt = conn.prepare_cached("SELECT value FROM settings WHERE key = ?1")?;
+pub fn get_setting(
+    conn: &Connection,
+    library_id: &str,
+    key: &str,
+) -> Result<Option<String>, AppError> {
+    let mut stmt =
+        conn.prepare_cached("SELECT value FROM settings WHERE library_id = ?1 AND key = ?2")?;
     let result = stmt
-        .query_row([key], |row| row.get(0))
+        .query_row(rusqlite::params![library_id, key], |row| row.get(0))
         .optional()
         .map_err(AppError::Database)?;
     Ok(result)
 }
 
-pub fn set_setting(conn: &Connection, key: &str, value: &str) -> Result<(), AppError> {
+pub fn set_setting(
+    conn: &Connection,
+    library_id: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), AppError> {
     conn.execute(
-        "INSERT INTO settings (key, value) VALUES (?1, ?2) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        rusqlite::params![key, value],
+        "INSERT INTO settings (library_id, key, value) VALUES (?1, ?2, ?3) ON CONFLICT(library_id, key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![library_id, key, value],
     )?;
     Ok(())
 }
@@ -26,35 +36,55 @@ const KEY_TYPE_LABEL_FOLDER: &str = "type_label_folder";
 const DEFAULT_TYPE_LABEL_IMAGE: &str = "Image";
 const DEFAULT_TYPE_LABEL_FOLDER: &str = "Folder";
 
-pub fn get_directory_template(conn: &Connection) -> Result<Option<String>, AppError> {
-    get_setting(conn, KEY_DIRECTORY_TEMPLATE)
+pub fn get_directory_template(
+    conn: &Connection,
+    library_id: &str,
+) -> Result<Option<String>, AppError> {
+    get_setting(conn, library_id, KEY_DIRECTORY_TEMPLATE)
 }
 
-pub fn set_directory_template(conn: &Connection, template: &str) -> Result<(), AppError> {
-    set_setting(conn, KEY_DIRECTORY_TEMPLATE, template)
+pub fn set_directory_template(
+    conn: &Connection,
+    library_id: &str,
+    template: &str,
+) -> Result<(), AppError> {
+    set_setting(conn, library_id, KEY_DIRECTORY_TEMPLATE, template)
 }
 
-pub fn get_type_label_image(conn: &Connection) -> Result<String, AppError> {
-    Ok(get_setting(conn, KEY_TYPE_LABEL_IMAGE)?.unwrap_or_else(|| DEFAULT_TYPE_LABEL_IMAGE.into()))
+pub fn get_type_label_image(conn: &Connection, library_id: &str) -> Result<String, AppError> {
+    Ok(get_setting(conn, library_id, KEY_TYPE_LABEL_IMAGE)?
+        .unwrap_or_else(|| DEFAULT_TYPE_LABEL_IMAGE.into()))
 }
 
-pub fn set_type_label_image(conn: &Connection, label: &str) -> Result<(), AppError> {
-    set_setting(conn, KEY_TYPE_LABEL_IMAGE, label)
+pub fn set_type_label_image(
+    conn: &Connection,
+    library_id: &str,
+    label: &str,
+) -> Result<(), AppError> {
+    set_setting(conn, library_id, KEY_TYPE_LABEL_IMAGE, label)
 }
 
-pub fn get_type_label_folder(conn: &Connection) -> Result<String, AppError> {
-    Ok(get_setting(conn, KEY_TYPE_LABEL_FOLDER)?
+pub fn get_type_label_folder(conn: &Connection, library_id: &str) -> Result<String, AppError> {
+    Ok(get_setting(conn, library_id, KEY_TYPE_LABEL_FOLDER)?
         .unwrap_or_else(|| DEFAULT_TYPE_LABEL_FOLDER.into()))
 }
 
-pub fn set_type_label_folder(conn: &Connection, label: &str) -> Result<(), AppError> {
-    set_setting(conn, KEY_TYPE_LABEL_FOLDER, label)
+pub fn set_type_label_folder(
+    conn: &Connection,
+    library_id: &str,
+    label: &str,
+) -> Result<(), AppError> {
+    set_setting(conn, library_id, KEY_TYPE_LABEL_FOLDER, label)
 }
 
-pub fn resolve_type_label(conn: &Connection, work_type: &str) -> Result<String, AppError> {
+pub fn resolve_type_label(
+    conn: &Connection,
+    library_id: &str,
+    work_type: &str,
+) -> Result<String, AppError> {
     match work_type {
-        "image" => get_type_label_image(conn),
-        "folder" => get_type_label_folder(conn),
+        "image" => get_type_label_image(conn, library_id),
+        "folder" => get_type_label_folder(conn, library_id),
         _ => Ok(work_type.to_string()),
     }
 }

--- a/src-tauri/src/tests/db.rs
+++ b/src-tauri/src/tests/db.rs
@@ -1,15 +1,32 @@
 use super::*;
+use crate::library;
 use rusqlite::Connection;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const TEST_LIBRARY_ID: &str = "test_lib_001";
 
 fn test_conn() -> Connection {
-    let conn = Connection::open_in_memory().unwrap();
-    init_db(&conn).unwrap();
+    let conn = open_db_in_memory().unwrap();
+    setup_test_library(&conn);
     conn
+}
+
+fn setup_test_library(conn: &Connection) {
+    library::add_library(conn, "Test Library", "/test/path").ok();
+    conn.execute(
+        "UPDATE libraries SET id = ?1 WHERE id = (SELECT id FROM libraries LIMIT 1)",
+        [TEST_LIBRARY_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE libraries SET is_active = 1 WHERE id = ?1",
+        [TEST_LIBRARY_ID],
+    )
+    .unwrap();
 }
 
 fn sample_record<'a>(title: &'a str, path: &'a str) -> WorkRecord<'a> {
     WorkRecord {
+        library_id: TEST_LIBRARY_ID,
         title,
         path,
         work_type: "image",
@@ -36,7 +53,7 @@ fn insert_and_list_round_trip() {
     insert_work(&conn, &sample_record("Alpha", "/a.jpg")).unwrap();
     insert_work(&conn, &sample_record("Beta", "/b.jpg")).unwrap();
 
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
     assert_eq!(works.len(), 2);
     assert_eq!(works[0].title, "Alpha");
     assert_eq!(works[1].title, "Beta");
@@ -47,8 +64,8 @@ fn path_exists_true_and_false() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("A", "/exists.jpg")).unwrap();
 
-    assert!(path_exists(&conn, "/exists.jpg").unwrap());
-    assert!(!path_exists(&conn, "/not_here.jpg").unwrap());
+    assert!(path_exists(&conn, TEST_LIBRARY_ID, "/exists.jpg").unwrap());
+    assert!(!path_exists(&conn, TEST_LIBRARY_ID, "/not_here.jpg").unwrap());
 }
 
 #[test]
@@ -65,7 +82,7 @@ fn list_works_sort_by_created_at_desc() {
     insert_work(&conn, &sample_record("First", "/1.jpg")).unwrap();
     insert_work(&conn, &sample_record("Second", "/2.jpg")).unwrap();
 
-    let works = list_works(&conn, "created_at", "desc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "created_at", "desc").unwrap();
     assert_eq!(works.len(), 2);
     assert!(works[0].created_at >= works[1].created_at);
 }
@@ -76,7 +93,7 @@ fn list_works_sort_by_title_desc() {
     insert_work(&conn, &sample_record("Alpha", "/a.jpg")).unwrap();
     insert_work(&conn, &sample_record("Beta", "/b.jpg")).unwrap();
 
-    let works = list_works(&conn, "title", "desc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "desc").unwrap();
     assert_eq!(works[0].title, "Beta");
     assert_eq!(works[1].title, "Alpha");
 }
@@ -85,7 +102,7 @@ fn list_works_sort_by_title_desc() {
 fn unknown_sort_by_falls_back_to_created_at() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("A", "/a.jpg")).unwrap();
-    let works = list_works(&conn, "invalid_column", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "invalid_column", "asc").unwrap();
     assert_eq!(works.len(), 1);
 }
 
@@ -94,7 +111,7 @@ fn get_thumbnail_returns_data() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("A", "/a.jpg")).unwrap();
 
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
     let thumb = get_thumbnail(&conn, works[0].id).unwrap();
     assert_eq!(thumb, b"fake_thumb");
 }
@@ -111,7 +128,7 @@ fn get_work_returns_detail() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("Title", "/path.jpg")).unwrap();
 
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
     let detail = get_work(&conn, works[0].id).unwrap();
     assert_eq!(detail.title, "Title");
     assert_eq!(detail.path, "/path.jpg");
@@ -134,6 +151,7 @@ fn get_work_not_found() {
 fn insert_work_with_metadata() {
     let conn = test_conn();
     let record = WorkRecord {
+        library_id: TEST_LIBRARY_ID,
         title: "My Work",
         path: "/meta.jpg",
         work_type: "image",
@@ -147,7 +165,7 @@ fn insert_work_with_metadata() {
     };
     insert_work(&conn, &record).unwrap();
 
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
     let detail = get_work(&conn, works[0].id).unwrap();
     assert_eq!(detail.artist.as_deref(), Some("Artist A"));
     assert_eq!(detail.year, Some(2024));
@@ -161,7 +179,7 @@ fn insert_work_with_metadata() {
 #[test]
 fn create_tag_returns_tag() {
     let conn = test_conn();
-    let tag = create_tag(&conn, "rust", Some("language")).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "rust", Some("language")).unwrap();
     assert_eq!(tag.name, "rust");
     assert_eq!(tag.category.as_deref(), Some("language"));
     assert!(tag.id > 0);
@@ -170,7 +188,7 @@ fn create_tag_returns_tag() {
 #[test]
 fn create_tag_without_category() {
     let conn = test_conn();
-    let tag = create_tag(&conn, "favorite", None).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "favorite", None).unwrap();
     assert_eq!(tag.name, "favorite");
     assert_eq!(tag.category, None);
 }
@@ -178,26 +196,26 @@ fn create_tag_without_category() {
 #[test]
 fn create_tag_duplicate_returns_error() {
     let conn = test_conn();
-    create_tag(&conn, "rust", Some("language")).unwrap();
-    let result = create_tag(&conn, "rust", Some("language"));
+    create_tag(&conn, TEST_LIBRARY_ID, "rust", Some("language")).unwrap();
+    let result = create_tag(&conn, TEST_LIBRARY_ID, "rust", Some("language"));
     assert!(result.is_err());
 }
 
 #[test]
 fn create_tag_same_name_different_category() {
     let conn = test_conn();
-    let t1 = create_tag(&conn, "action", Some("genre")).unwrap();
-    let t2 = create_tag(&conn, "action", Some("theme")).unwrap();
+    let t1 = create_tag(&conn, TEST_LIBRARY_ID, "action", Some("genre")).unwrap();
+    let t2 = create_tag(&conn, TEST_LIBRARY_ID, "action", Some("theme")).unwrap();
     assert_ne!(t1.id, t2.id);
 }
 
 #[test]
 fn update_tag_changes_name_and_category() {
     let conn = test_conn();
-    let tag = create_tag(&conn, "old", Some("cat")).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "old", Some("cat")).unwrap();
     update_tag(&conn, tag.id, "new", Some("newcat")).unwrap();
 
-    let tags = search_tags(&conn, "new", None).unwrap();
+    let tags = search_tags(&conn, TEST_LIBRARY_ID, "new", None).unwrap();
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].name, "new");
     assert_eq!(tags[0].category.as_deref(), Some("newcat"));
@@ -213,10 +231,10 @@ fn update_tag_not_found() {
 #[test]
 fn delete_tag_removes_it() {
     let conn = test_conn();
-    let tag = create_tag(&conn, "temp", None).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "temp", None).unwrap();
     delete_tag(&conn, tag.id).unwrap();
 
-    let tags = search_tags(&conn, "temp", None).unwrap();
+    let tags = search_tags(&conn, TEST_LIBRARY_ID, "temp", None).unwrap();
     assert!(tags.is_empty());
 }
 
@@ -231,8 +249,8 @@ fn delete_tag_not_found() {
 fn delete_tag_cascades_works_tags() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W", "/w.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
-    let tag = create_tag(&conn, "to_delete", None).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "to_delete", None).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
 
     delete_tag(&conn, tag.id).unwrap();
@@ -245,10 +263,10 @@ fn delete_tag_cascades_works_tags() {
 #[test]
 fn search_tags_partial_match() {
     let conn = test_conn();
-    create_tag(&conn, "fantasy", Some("genre")).unwrap();
-    create_tag(&conn, "sci-fi", Some("genre")).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "fantasy", Some("genre")).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "sci-fi", Some("genre")).unwrap();
 
-    let tags = search_tags(&conn, "fan", None).unwrap();
+    let tags = search_tags(&conn, TEST_LIBRARY_ID, "fan", None).unwrap();
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].name, "fantasy");
 }
@@ -256,10 +274,10 @@ fn search_tags_partial_match() {
 #[test]
 fn search_tags_with_category_filter() {
     let conn = test_conn();
-    create_tag(&conn, "action", Some("genre")).unwrap();
-    create_tag(&conn, "action_hero", Some("character")).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "action", Some("genre")).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "action_hero", Some("character")).unwrap();
 
-    let tags = search_tags(&conn, "action", Some("genre")).unwrap();
+    let tags = search_tags(&conn, TEST_LIBRARY_ID, "action", Some("genre")).unwrap();
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].category.as_deref(), Some("genre"));
 }
@@ -267,10 +285,10 @@ fn search_tags_with_category_filter() {
 #[test]
 fn search_tags_empty_query_returns_all() {
     let conn = test_conn();
-    create_tag(&conn, "a", None).unwrap();
-    create_tag(&conn, "b", None).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "a", None).unwrap();
+    create_tag(&conn, TEST_LIBRARY_ID, "b", None).unwrap();
 
-    let tags = search_tags(&conn, "", None).unwrap();
+    let tags = search_tags(&conn, TEST_LIBRARY_ID, "", None).unwrap();
     assert_eq!(tags.len(), 2);
 }
 
@@ -280,9 +298,9 @@ fn search_tags_empty_query_returns_all() {
 fn add_and_get_tags_for_work() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W1", "/w1.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
-    let t1 = create_tag(&conn, "tag_b", None).unwrap();
-    let t2 = create_tag(&conn, "tag_a", None).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let t1 = create_tag(&conn, TEST_LIBRARY_ID, "tag_b", None).unwrap();
+    let t2 = create_tag(&conn, TEST_LIBRARY_ID, "tag_a", None).unwrap();
     add_tag_to_work(&conn, works[0].id, t1.id).unwrap();
     add_tag_to_work(&conn, works[0].id, t2.id).unwrap();
 
@@ -296,8 +314,8 @@ fn add_and_get_tags_for_work() {
 fn add_tag_to_work_idempotent() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W1", "/w1.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
-    let tag = create_tag(&conn, "dup", None).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "dup", None).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
 
@@ -309,8 +327,8 @@ fn add_tag_to_work_idempotent() {
 fn remove_tag_from_work_removes_association() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W1", "/w1.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
-    let tag = create_tag(&conn, "rm", None).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "rm", None).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
     remove_tag_from_work(&conn, works[0].id, tag.id).unwrap();
 
@@ -322,8 +340,8 @@ fn remove_tag_from_work_removes_association() {
 fn remove_tag_from_work_idempotent() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W1", "/w1.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
-    let tag = create_tag(&conn, "rm2", None).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "rm2", None).unwrap();
     remove_tag_from_work(&conn, works[0].id, tag.id).unwrap();
 }
 
@@ -331,7 +349,7 @@ fn remove_tag_from_work_idempotent() {
 fn get_tags_for_work_empty() {
     let conn = test_conn();
     insert_work(&conn, &sample_record("W1", "/w1.jpg")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
 
     let tags = get_tags_for_work(&conn, works[0].id).unwrap();
     assert!(tags.is_empty());
@@ -345,14 +363,14 @@ fn search_works_by_tags_or_mode() {
     insert_work(&conn, &sample_folder_record("W1", "/w1")).unwrap();
     insert_work(&conn, &sample_folder_record("W2", "/w2")).unwrap();
     insert_work(&conn, &sample_folder_record("W3", "/w3")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
 
-    let t1 = create_tag(&conn, "tag1", None).unwrap();
-    let t2 = create_tag(&conn, "tag2", None).unwrap();
+    let t1 = create_tag(&conn, TEST_LIBRARY_ID, "tag1", None).unwrap();
+    let t2 = create_tag(&conn, TEST_LIBRARY_ID, "tag2", None).unwrap();
     add_tag_to_work(&conn, works[0].id, t1.id).unwrap();
     add_tag_to_work(&conn, works[1].id, t2.id).unwrap();
 
-    let result = search_works_by_tags(&conn, &[t1.id, t2.id], "or").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[t1.id, t2.id], "or").unwrap();
     assert_eq!(result.len(), 2);
 }
 
@@ -361,15 +379,15 @@ fn search_works_by_tags_and_mode() {
     let conn = test_conn();
     insert_work(&conn, &sample_folder_record("W1", "/w1")).unwrap();
     insert_work(&conn, &sample_folder_record("W2", "/w2")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
 
-    let t1 = create_tag(&conn, "tag1", None).unwrap();
-    let t2 = create_tag(&conn, "tag2", None).unwrap();
+    let t1 = create_tag(&conn, TEST_LIBRARY_ID, "tag1", None).unwrap();
+    let t2 = create_tag(&conn, TEST_LIBRARY_ID, "tag2", None).unwrap();
     add_tag_to_work(&conn, works[0].id, t1.id).unwrap();
     add_tag_to_work(&conn, works[0].id, t2.id).unwrap();
     add_tag_to_work(&conn, works[1].id, t1.id).unwrap();
 
-    let result = search_works_by_tags(&conn, &[t1.id, t2.id], "and").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[t1.id, t2.id], "and").unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].title, "W1");
 }
@@ -377,7 +395,7 @@ fn search_works_by_tags_and_mode() {
 #[test]
 fn search_works_by_tags_empty_ids() {
     let conn = test_conn();
-    let result = search_works_by_tags(&conn, &[], "or").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[], "or").unwrap();
     assert!(result.is_empty());
 }
 
@@ -385,9 +403,9 @@ fn search_works_by_tags_empty_ids() {
 fn search_works_by_tags_no_match() {
     let conn = test_conn();
     insert_work(&conn, &sample_folder_record("W1", "/w1")).unwrap();
-    let t1 = create_tag(&conn, "unused", None).unwrap();
+    let t1 = create_tag(&conn, TEST_LIBRARY_ID, "unused", None).unwrap();
 
-    let result = search_works_by_tags(&conn, &[t1.id], "or").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[t1.id], "or").unwrap();
     assert!(result.is_empty());
 }
 
@@ -396,13 +414,13 @@ fn search_works_by_tags_ordered_by_created_at_desc() {
     let conn = test_conn();
     insert_work(&conn, &sample_folder_record("First", "/f1")).unwrap();
     insert_work(&conn, &sample_folder_record("Second", "/f2")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
 
-    let tag = create_tag(&conn, "shared", None).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "shared", None).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
     add_tag_to_work(&conn, works[1].id, tag.id).unwrap();
 
-    let result = search_works_by_tags(&conn, &[tag.id], "or").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[tag.id], "or").unwrap();
     assert_eq!(result.len(), 2);
     assert!(result[0].created_at >= result[1].created_at);
 }
@@ -411,28 +429,25 @@ fn search_works_by_tags_ordered_by_created_at_desc() {
 fn search_works_by_tags_and_mode_deduplicates_ids() {
     let conn = test_conn();
     insert_work(&conn, &sample_folder_record("W1", "/w1")).unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
 
-    let tag = create_tag(&conn, "only", None).unwrap();
+    let tag = create_tag(&conn, TEST_LIBRARY_ID, "only", None).unwrap();
     add_tag_to_work(&conn, works[0].id, tag.id).unwrap();
 
-    let result = search_works_by_tags(&conn, &[tag.id, tag.id], "and").unwrap();
+    let result = search_works_by_tags(&conn, TEST_LIBRARY_ID, &[tag.id, tag.id], "and").unwrap();
     assert_eq!(result.len(), 1);
 }
 
 // --- database is locked reproduction ---
 
 fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!("sharaku_test_{}_{}", prefix, ts))
 }
 
-/// Reproduce "database is locked" error:
-/// An external process (e.g. GNOME tracker-miner-fs) briefly holds an exclusive
-/// lock on the newly created database file while open_db tries to run migrations.
 #[test]
 fn open_db_succeeds_despite_brief_external_lock() {
     let dir = unique_temp_dir("locked");
@@ -440,15 +455,13 @@ fn open_db_succeeds_despite_brief_external_lock() {
 
     let db_path = dir.join("sharaku.db");
 
-    // Simulate an external process holding an exclusive lock on the db file
     let blocker = Connection::open(&db_path).unwrap();
     blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
 
     let dir_clone = dir.clone();
     let handle = std::thread::spawn(move || open_db(&dir_clone));
 
-    // Release the lock after 200ms (well within the busy_timeout window)
-    std::thread::sleep(Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_millis(200));
     blocker.execute_batch("ROLLBACK").unwrap();
     drop(blocker);
 
@@ -459,9 +472,10 @@ fn open_db_succeeds_despite_brief_external_lock() {
         result.err()
     );
 
-    // Verify the database is usable
     let conn = result.unwrap();
-    let works = list_works(&conn, "title", "asc").unwrap();
+    library::add_library(&conn, "Test", "/test").unwrap();
+    let lib_id = library::active_library(&conn).unwrap().unwrap().id;
+    let works = list_works(&conn, &lib_id, "title", "asc").unwrap();
     assert_eq!(works.len(), 0);
 
     drop(conn);

--- a/src-tauri/src/tests/library.rs
+++ b/src-tauri/src/tests/library.rs
@@ -1,126 +1,128 @@
 use super::*;
+use crate::db;
 
-fn temp_store(name: &str) -> LibraryStore {
-    let dir = std::env::temp_dir().join(format!("sharaku_test_library_{name}"));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    LibraryStore::new(&dir)
+fn test_conn() -> rusqlite::Connection {
+    db::open_db_in_memory().unwrap()
 }
 
 #[test]
-fn load_empty_returns_empty() {
-    let store = temp_store("load_empty");
-    let (libs, active) = store.load().unwrap();
+fn list_empty_returns_empty() {
+    let conn = test_conn();
+    let libs = list_libraries(&conn).unwrap();
     assert!(libs.is_empty());
-    assert!(active.is_none());
 }
 
 #[test]
 fn add_library_creates_entry() {
-    let store = temp_store("add");
-    let lib = store.add("Photos", "/path/to/photos").unwrap();
+    let conn = test_conn();
+    let lib = add_library(&conn, "Photos", "/path/to/photos").unwrap();
     assert_eq!(lib.name, "Photos");
     assert_eq!(lib.path, "/path/to/photos");
     assert!(!lib.id.is_empty());
 
-    let (libs, active) = store.load().unwrap();
+    let libs = list_libraries(&conn).unwrap();
     assert_eq!(libs.len(), 1);
-    assert_eq!(active.as_deref(), Some(lib.id.as_str()));
+
+    let active = active_library(&conn).unwrap();
+    assert!(active.is_some());
+    assert_eq!(active.unwrap().id, lib.id);
 }
 
 #[test]
 fn add_duplicate_path_returns_error() {
-    let store = temp_store("dup_path");
-    store.add("Photos", "/same/path").unwrap();
-    let result = store.add("Another", "/same/path");
+    let conn = test_conn();
+    add_library(&conn, "Photos", "/same/path").unwrap();
+    let result = add_library(&conn, "Another", "/same/path");
     assert!(result.is_err());
 }
 
 #[test]
 fn add_second_library_keeps_first_active() {
-    let store = temp_store("second");
-    let first = store.add("First", "/first").unwrap();
-    store.add("Second", "/second").unwrap();
+    let conn = test_conn();
+    let first = add_library(&conn, "First", "/first").unwrap();
+    add_library(&conn, "Second", "/second").unwrap();
 
-    let (_, active) = store.load().unwrap();
-    assert_eq!(active.as_deref(), Some(first.id.as_str()));
+    let active = active_library(&conn).unwrap().unwrap();
+    assert_eq!(active.id, first.id);
 }
 
 #[test]
-fn remove_library() {
-    let store = temp_store("remove");
-    let lib = store.add("ToRemove", "/remove").unwrap();
-    store.remove(&lib.id).unwrap();
+fn remove_library_removes_entry() {
+    let conn = test_conn();
+    let lib = add_library(&conn, "ToRemove", "/remove").unwrap();
+    remove_library(&conn, &lib.id).unwrap();
 
-    let (libs, _) = store.load().unwrap();
+    let libs = list_libraries(&conn).unwrap();
     assert!(libs.is_empty());
 }
 
 #[test]
 fn remove_active_library_activates_next() {
-    let store = temp_store("remove_active");
-    let first = store.add("First", "/first").unwrap();
-    let second = store.add("Second", "/second").unwrap();
+    let conn = test_conn();
+    let first = add_library(&conn, "First", "/first").unwrap();
+    let second = add_library(&conn, "Second", "/second").unwrap();
 
-    store.remove(&first.id).unwrap();
-    let (libs, active) = store.load().unwrap();
+    remove_library(&conn, &first.id).unwrap();
+    let libs = list_libraries(&conn).unwrap();
     assert_eq!(libs.len(), 1);
-    assert_eq!(active.as_deref(), Some(second.id.as_str()));
+
+    let active = active_library(&conn).unwrap().unwrap();
+    assert_eq!(active.id, second.id);
 }
 
 #[test]
 fn remove_nonexistent_returns_error() {
-    let store = temp_store("remove_nonexistent");
-    let result = store.remove("fake_id");
+    let conn = test_conn();
+    let result = remove_library(&conn, "fake_id");
     assert!(result.is_err());
 }
 
 #[test]
 fn set_active() {
-    let store = temp_store("set_active");
-    store.add("First", "/first").unwrap();
-    let second = store.add("Second", "/second").unwrap();
+    let conn = test_conn();
+    add_library(&conn, "First", "/first").unwrap();
+    let second = add_library(&conn, "Second", "/second").unwrap();
 
-    store.set_active(&second.id).unwrap();
-    let (_, active) = store.load().unwrap();
-    assert_eq!(active.as_deref(), Some(second.id.as_str()));
+    set_active_library(&conn, &second.id).unwrap();
+    let active = active_library(&conn).unwrap().unwrap();
+    assert_eq!(active.id, second.id);
 }
 
 #[test]
 fn set_active_nonexistent_returns_error() {
-    let store = temp_store("set_active_nonexistent");
-    let result = store.set_active("fake_id");
+    let conn = test_conn();
+    let result = set_active_library(&conn, "fake_id");
     assert!(result.is_err());
 }
 
 #[test]
 fn find_by_id_found() {
-    let store = temp_store("find");
-    let lib = store.add("Test", "/test").unwrap();
-    let found = store.find_by_id(&lib.id).unwrap();
+    let conn = test_conn();
+    let lib = add_library(&conn, "Test", "/test").unwrap();
+    let found = find_library_by_id(&conn, &lib.id).unwrap();
     assert!(found.is_some());
     assert_eq!(found.unwrap().name, "Test");
 }
 
 #[test]
 fn find_by_id_not_found() {
-    let store = temp_store("find_not_found");
-    let found = store.find_by_id("fake_id").unwrap();
+    let conn = test_conn();
+    let found = find_library_by_id(&conn, "fake_id").unwrap();
     assert!(found.is_none());
 }
 
 #[test]
 fn active_library_returns_active() {
-    let store = temp_store("active");
-    let lib = store.add("Active", "/active").unwrap();
-    let active = store.active_library().unwrap();
+    let conn = test_conn();
+    let lib = add_library(&conn, "Active", "/active").unwrap();
+    let active = active_library(&conn).unwrap();
     assert!(active.is_some());
     assert_eq!(active.unwrap().id, lib.id);
 }
 
 #[test]
 fn active_library_returns_none_when_empty() {
-    let store = temp_store("active_empty");
-    let active = store.active_library().unwrap();
+    let conn = test_conn();
+    let active = active_library(&conn).unwrap();
     assert!(active.is_none());
 }

--- a/src-tauri/src/tests/relocator.rs
+++ b/src-tauri/src/tests/relocator.rs
@@ -3,12 +3,20 @@ use std::path::Path;
 use rusqlite::Connection;
 
 use crate::db::{self, WorkRecord};
+use crate::library;
 
 use super::*;
 
+const TEST_LIBRARY_ID: &str = "test_lib_relocator";
+
 fn setup_test_db() -> Connection {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db_for_test(&conn).unwrap();
+    let conn = db::open_db_in_memory().unwrap();
+    library::add_library(&conn, "Test", "/test").ok();
+    conn.execute(
+        "UPDATE libraries SET id = ?1 WHERE id = (SELECT id FROM libraries LIMIT 1)",
+        [TEST_LIBRARY_ID],
+    )
+    .unwrap();
     conn
 }
 
@@ -16,6 +24,7 @@ fn insert_folder_work(conn: &Connection, title: &str, path: &str, artist: Option
     db::insert_work(
         conn,
         &WorkRecord {
+            library_id: TEST_LIBRARY_ID,
             title,
             path,
             work_type: "folder",
@@ -34,7 +43,8 @@ fn insert_folder_work(conn: &Connection, title: &str, path: &str, artist: Option
 #[test]
 fn preview_empty_when_no_folder_works() {
     let conn = setup_test_db();
-    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    let previews =
+        preview_relocation(&conn, TEST_LIBRARY_ID, Path::new("/library"), "{title}").unwrap();
     assert!(previews.is_empty());
 }
 
@@ -42,7 +52,8 @@ fn preview_empty_when_no_folder_works() {
 fn preview_empty_when_path_unchanged() {
     let conn = setup_test_db();
     insert_folder_work(&conn, "MyWork", "/library/MyWork", None);
-    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    let previews =
+        preview_relocation(&conn, TEST_LIBRARY_ID, Path::new("/library"), "{title}").unwrap();
     assert!(previews.is_empty());
 }
 
@@ -50,7 +61,13 @@ fn preview_empty_when_path_unchanged() {
 fn preview_shows_changed_paths() {
     let conn = setup_test_db();
     insert_folder_work(&conn, "MyWork", "/library/old_location", Some("Artist"));
-    let previews = preview_relocation(&conn, Path::new("/library"), "{artist}/{title}").unwrap();
+    let previews = preview_relocation(
+        &conn,
+        TEST_LIBRARY_ID,
+        Path::new("/library"),
+        "{artist}/{title}",
+    )
+    .unwrap();
     assert_eq!(previews.len(), 1);
     assert_eq!(previews[0].old_path, "/library/old_location");
     assert_eq!(previews[0].new_path, "/library/Artist/MyWork");
@@ -63,6 +80,7 @@ fn preview_skips_image_type_works() {
     db::insert_work(
         &conn,
         &WorkRecord {
+            library_id: TEST_LIBRARY_ID,
             title: "ImageWork",
             path: "/library/image.jpg",
             work_type: "image",
@@ -76,7 +94,8 @@ fn preview_skips_image_type_works() {
         },
     )
     .unwrap();
-    let previews = preview_relocation(&conn, Path::new("/library"), "{title}").unwrap();
+    let previews =
+        preview_relocation(&conn, TEST_LIBRARY_ID, Path::new("/library"), "{title}").unwrap();
     assert!(previews.is_empty());
 }
 
@@ -85,7 +104,13 @@ fn preview_multiple_works_different_paths() {
     let conn = setup_test_db();
     insert_folder_work(&conn, "Work1", "/library/old1", Some("A"));
     insert_folder_work(&conn, "Work2", "/library/old2", Some("B"));
-    let previews = preview_relocation(&conn, Path::new("/library"), "{artist}/{title}").unwrap();
+    let previews = preview_relocation(
+        &conn,
+        TEST_LIBRARY_ID,
+        Path::new("/library"),
+        "{artist}/{title}",
+    )
+    .unwrap();
     assert_eq!(previews.len(), 2);
 }
 
@@ -100,16 +125,15 @@ fn execute_moves_files_and_updates_db() {
     std::fs::write(old_dir.join("01.jpg"), b"image_data").unwrap();
     std::fs::write(old_dir.join("02.png"), b"image_data2").unwrap();
 
-    let conn = db::open_db(&library_root).unwrap();
-    crate::settings::set_directory_template(&conn, "{title}").unwrap();
+    let conn = setup_test_db();
+    crate::settings::set_directory_template(&conn, TEST_LIBRARY_ID, "{title}").unwrap();
     insert_folder_work(&conn, "MyWork", &old_dir.to_string_lossy(), Some("Artist"));
 
-    let works = db::list_folder_works(&conn).unwrap();
+    let works = db::list_folder_works(&conn, TEST_LIBRARY_ID).unwrap();
     let plan = compute_relocation_plan(&works, &library_root, "{artist}/{title}", "Folder");
     assert_eq!(plan.len(), 1);
     assert!(plan[0].new_path.contains("Artist"));
 
-    // Verify files moved correctly
     let new_dir = library_root.join("Artist").join("MyWork");
     std::fs::create_dir_all(&new_dir).unwrap();
     let images = importer::list_images_in_folder(&old_dir).unwrap();
@@ -132,7 +156,7 @@ fn compute_plan_handles_path_collision() {
     insert_folder_work(&conn, "SameTitle", "/library/folder_a", Some("Artist"));
     insert_folder_work(&conn, "SameTitle", "/library/folder_b", Some("Artist"));
 
-    let works = db::list_folder_works(&conn).unwrap();
+    let works = db::list_folder_works(&conn, TEST_LIBRARY_ID).unwrap();
     let plan = compute_relocation_plan(&works, Path::new("/library"), "{artist}/{title}", "Folder");
 
     assert_eq!(plan.len(), 2);
@@ -169,7 +193,6 @@ fn cleanup_empty_ancestors_removes_empty_dirs() {
     let nested = stop.join("a").join("b").join("c");
     std::fs::create_dir_all(&nested).unwrap();
 
-    // Simulate: leaf directory already removed (as in move_work_files)
     std::fs::remove_dir(&nested).unwrap();
 
     cleanup_empty_ancestors(&nested, &stop);
@@ -191,7 +214,6 @@ fn cleanup_empty_ancestors_stops_at_non_empty() {
     std::fs::create_dir_all(&child).unwrap();
     std::fs::write(parent.join("other_file.txt"), b"data").unwrap();
 
-    // Simulate: leaf directory already removed
     std::fs::remove_dir(&child).unwrap();
 
     cleanup_empty_ancestors(&child, &stop);

--- a/src-tauri/src/tests/settings.rs
+++ b/src-tauri/src/tests/settings.rs
@@ -1,43 +1,61 @@
-use rusqlite::Connection;
-
-use crate::db;
-
 use super::*;
 
-fn test_conn() -> Connection {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db_for_test(&conn).unwrap();
+use crate::db;
+use crate::library;
+
+const TEST_LIBRARY_ID: &str = "test_lib_settings";
+
+fn test_conn() -> rusqlite::Connection {
+    let conn = db::open_db_in_memory().unwrap();
+    library::add_library(&conn, "Test", "/test").ok();
+    conn.execute(
+        "UPDATE libraries SET id = ?1 WHERE id = (SELECT id FROM libraries LIMIT 1)",
+        [TEST_LIBRARY_ID],
+    )
+    .unwrap();
     conn
 }
 
 #[test]
 fn get_setting_returns_none_when_not_set() {
     let conn = test_conn();
-    assert_eq!(get_setting(&conn, "nonexistent").unwrap(), None);
+    assert_eq!(
+        get_setting(&conn, TEST_LIBRARY_ID, "nonexistent").unwrap(),
+        None
+    );
 }
 
 #[test]
 fn set_and_get_setting() {
     let conn = test_conn();
-    set_setting(&conn, "key1", "value1").unwrap();
-    assert_eq!(get_setting(&conn, "key1").unwrap(), Some("value1".into()));
+    set_setting(&conn, TEST_LIBRARY_ID, "key1", "value1").unwrap();
+    assert_eq!(
+        get_setting(&conn, TEST_LIBRARY_ID, "key1").unwrap(),
+        Some("value1".into())
+    );
 }
 
 #[test]
 fn set_setting_overwrites_existing() {
     let conn = test_conn();
-    set_setting(&conn, "key1", "old").unwrap();
-    set_setting(&conn, "key1", "new").unwrap();
-    assert_eq!(get_setting(&conn, "key1").unwrap(), Some("new".into()));
+    set_setting(&conn, TEST_LIBRARY_ID, "key1", "old").unwrap();
+    set_setting(&conn, TEST_LIBRARY_ID, "key1", "new").unwrap();
+    assert_eq!(
+        get_setting(&conn, TEST_LIBRARY_ID, "key1").unwrap(),
+        Some("new".into())
+    );
 }
 
 #[test]
 fn directory_template_helpers() {
     let conn = test_conn();
-    assert_eq!(get_directory_template(&conn).unwrap(), None);
-    set_directory_template(&conn, "{artist}/{title}").unwrap();
     assert_eq!(
-        get_directory_template(&conn).unwrap(),
+        get_directory_template(&conn, TEST_LIBRARY_ID).unwrap(),
+        None
+    );
+    set_directory_template(&conn, TEST_LIBRARY_ID, "{artist}/{title}").unwrap();
+    assert_eq!(
+        get_directory_template(&conn, TEST_LIBRARY_ID).unwrap(),
         Some("{artist}/{title}".into())
     );
 }
@@ -45,24 +63,45 @@ fn directory_template_helpers() {
 #[test]
 fn type_label_defaults() {
     let conn = test_conn();
-    assert_eq!(get_type_label_image(&conn).unwrap(), "Image");
-    assert_eq!(get_type_label_folder(&conn).unwrap(), "Folder");
+    assert_eq!(
+        get_type_label_image(&conn, TEST_LIBRARY_ID).unwrap(),
+        "Image"
+    );
+    assert_eq!(
+        get_type_label_folder(&conn, TEST_LIBRARY_ID).unwrap(),
+        "Folder"
+    );
 }
 
 #[test]
 fn type_label_set_and_get() {
     let conn = test_conn();
-    set_type_label_image(&conn, "イラスト").unwrap();
-    set_type_label_folder(&conn, "漫画").unwrap();
-    assert_eq!(get_type_label_image(&conn).unwrap(), "イラスト");
-    assert_eq!(get_type_label_folder(&conn).unwrap(), "漫画");
+    set_type_label_image(&conn, TEST_LIBRARY_ID, "イラスト").unwrap();
+    set_type_label_folder(&conn, TEST_LIBRARY_ID, "漫画").unwrap();
+    assert_eq!(
+        get_type_label_image(&conn, TEST_LIBRARY_ID).unwrap(),
+        "イラスト"
+    );
+    assert_eq!(
+        get_type_label_folder(&conn, TEST_LIBRARY_ID).unwrap(),
+        "漫画"
+    );
 }
 
 #[test]
 fn resolve_type_label_uses_settings() {
     let conn = test_conn();
-    set_type_label_folder(&conn, "漫画").unwrap();
-    assert_eq!(resolve_type_label(&conn, "folder").unwrap(), "漫画");
-    assert_eq!(resolve_type_label(&conn, "image").unwrap(), "Image");
-    assert_eq!(resolve_type_label(&conn, "other").unwrap(), "other");
+    set_type_label_folder(&conn, TEST_LIBRARY_ID, "漫画").unwrap();
+    assert_eq!(
+        resolve_type_label(&conn, TEST_LIBRARY_ID, "folder").unwrap(),
+        "漫画"
+    );
+    assert_eq!(
+        resolve_type_label(&conn, TEST_LIBRARY_ID, "image").unwrap(),
+        "Image"
+    );
+    assert_eq!(
+        resolve_type_label(&conn, TEST_LIBRARY_ID, "other").unwrap(),
+        "other"
+    );
 }


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/48

# 変更点

- 各ライブラリディレクトリに配置していたper-library `sharaku.db` を廃止し、`app_data_dir` 内の単一DBに統合
  - CIFS/SMB上ではSQLiteのファイルロック(fcntl)が動作しないため、DBを常にローカルFSに配置する設計に変更
- `library_id` カラムで全データテーブル（works, tags, settings, playlists）をライブラリ単位に分離
- `libraries.json` によるライブラリ管理をSQLiteの `libraries` テーブルに移行
  - 既存の `libraries.json` はアプリ起動時に自動マイグレーション
- ライブラリ切り替え時のDB接続再作成が不要になりAppStateが簡素化
  - `Arc<Mutex<Option<ActiveLibrary{path, conn}>>>` → `Arc<Mutex<AppDb{conn, active_library}>>`

# 備考

- 既存per-library DBのworksデータ移行は #49 で対応予定（本PRのスコープ外）
- フロントエンドのAPI surfaceは不変のため、フロントエンド変更なし