### PR TITLE
[#56] 開発ビルドとリリースビルドでデータディレクトリを分離

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -647,7 +647,14 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
-            let app_data_dir = app.path().app_data_dir()?;
+            let app_data_dir = {
+                let base = app.path().app_data_dir()?;
+                if cfg!(debug_assertions) {
+                    base.with_file_name("com.sharaku.viewer.dev")
+                } else {
+                    base
+                }
+            };
 
             let conn = db::open_db(&app_data_dir).expect("Failed to open database");
             migrate_libraries_json(&conn, &app_data_dir);


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/56

# 変更点

- 開発ビルド（`debug_assertions`有効時）のデータディレクトリを `com.sharaku.viewer.dev` に変更し、リリースビルドと分離
- `cfg!(debug_assertions)` による コンパイル時分岐で、リリースビルドの動作には一切影響なし

# 備考

- 開発ビルドで新しいディレクトリが使われるため、既存の開発データは引き継がれない（意図通り）