### PR TITLE
[#70] 作品のメタデータ編集機能を追加

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -207,6 +207,27 @@ pub fn list_folder_works(conn: &Connection, library_id: &str) -> Result<Vec<Work
     Ok(works)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn update_work(
+    conn: &Connection,
+    id: i64,
+    title: &str,
+    artist: Option<&str>,
+    year: Option<i32>,
+    genre: Option<&str>,
+    circle: Option<&str>,
+    origin: Option<&str>,
+) -> Result<(), AppError> {
+    let rows = conn.execute(
+        "UPDATE works SET title = ?1, artist = ?2, year = ?3, genre = ?4, circle = ?5, origin = ?6, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?7",
+        rusqlite::params![title, artist, year, genre, circle, origin, id],
+    )?;
+    if rows == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(())
+}
+
 pub fn update_work_path(conn: &Connection, work_id: i64, new_path: &str) -> Result<(), AppError> {
     conn.execute(
         "UPDATE works SET path = ?1 WHERE id = ?2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -554,6 +554,45 @@ async fn create_tag(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
+async fn update_work(
+    state: tauri::State<'_, AppState>,
+    id: i64,
+    title: String,
+    artist: Option<String>,
+    year: Option<i32>,
+    genre: Option<String>,
+    circle: Option<String>,
+    origin: Option<String>,
+) -> Result<(), String> {
+    let title = title.trim().to_string();
+    if title.is_empty() {
+        return Err("タイトルは空にできません".to_string());
+    }
+    let db = state.db.clone();
+    tokio::task::spawn_blocking(move || {
+        let guard = db.lock().unwrap();
+        guard
+            .active_library
+            .as_ref()
+            .ok_or("ライブラリが選択されていません")?;
+        db::update_work(
+            &guard.conn,
+            id,
+            &title,
+            artist.as_deref(),
+            year,
+            genre.as_deref(),
+            circle.as_deref(),
+            origin.as_deref(),
+        )
+        .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
 async fn update_tag(
     state: tauri::State<'_, AppState>,
     id: i64,
@@ -826,6 +865,7 @@ pub fn run() {
             list_works,
             get_thumbnail,
             get_work,
+            update_work,
             get_settings,
             set_resource_mode,
             set_directory_template,

--- a/src-tauri/src/tests/db.rs
+++ b/src-tauri/src/tests/db.rs
@@ -564,6 +564,87 @@ fn delete_works_by_ids_cascades_tags() {
     assert!(tags.is_empty());
 }
 
+// --- update_work ---
+
+#[test]
+fn update_work_changes_metadata() {
+    let conn = test_conn();
+    let record = WorkRecord {
+        library_id: TEST_LIBRARY_ID,
+        title: "Original",
+        path: "/orig.jpg",
+        work_type: "image",
+        page_count: 1,
+        thumbnail: b"thumb",
+        artist: Some("Old Artist"),
+        year: Some(2020),
+        genre: Some("Old Genre"),
+        circle: Some("Old Circle"),
+        origin: Some("Old Origin"),
+    };
+    insert_work(&conn, &record).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let id = works[0].id;
+
+    update_work(
+        &conn,
+        id,
+        "Updated Title",
+        Some("New Artist"),
+        Some(2025),
+        Some("New Genre"),
+        Some("New Circle"),
+        Some("New Origin"),
+    )
+    .unwrap();
+
+    let detail = get_work(&conn, id).unwrap();
+    assert_eq!(detail.title, "Updated Title");
+    assert_eq!(detail.artist.as_deref(), Some("New Artist"));
+    assert_eq!(detail.year, Some(2025));
+    assert_eq!(detail.genre.as_deref(), Some("New Genre"));
+    assert_eq!(detail.circle.as_deref(), Some("New Circle"));
+    assert_eq!(detail.origin.as_deref(), Some("New Origin"));
+}
+
+#[test]
+fn update_work_not_found() {
+    let conn = test_conn();
+    let result = update_work(&conn, 9999, "Title", None, None, None, None, None);
+    assert!(matches!(result, Err(AppError::NotFound)));
+}
+
+#[test]
+fn update_work_clears_optional_fields() {
+    let conn = test_conn();
+    let record = WorkRecord {
+        library_id: TEST_LIBRARY_ID,
+        title: "Work",
+        path: "/w.jpg",
+        work_type: "image",
+        page_count: 1,
+        thumbnail: b"thumb",
+        artist: Some("Artist"),
+        year: Some(2024),
+        genre: Some("Genre"),
+        circle: Some("Circle"),
+        origin: Some("Origin"),
+    };
+    insert_work(&conn, &record).unwrap();
+    let works = list_works(&conn, TEST_LIBRARY_ID, "title", "asc").unwrap();
+    let id = works[0].id;
+
+    update_work(&conn, id, "Work", None, None, None, None, None).unwrap();
+
+    let detail = get_work(&conn, id).unwrap();
+    assert_eq!(detail.title, "Work");
+    assert_eq!(detail.artist, None);
+    assert_eq!(detail.year, None);
+    assert_eq!(detail.genre, None);
+    assert_eq!(detail.circle, None);
+    assert_eq!(detail.origin, None);
+}
+
 // --- database is locked reproduction ---
 
 fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {

--- a/src/app.css
+++ b/src/app.css
@@ -2060,6 +2060,119 @@ button:disabled {
 }
 
 /* ============================
+   Context Menu
+   ============================ */
+
+.context-menu {
+  position: fixed;
+  z-index: 400;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  padding: 4px 0;
+  min-width: 160px;
+}
+
+.context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  text-align: left;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: #333;
+}
+
+.context-menu-item:hover {
+  background: #f0f0f0;
+  border-color: transparent;
+}
+
+/* ============================
+   Edit Work Dialog
+   ============================ */
+
+.edit-work-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.edit-work-dialog {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 420px;
+  max-width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.edit-work-dialog-title {
+  margin: 0 0 16px;
+  font-size: 1.1rem;
+}
+
+.edit-work-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.edit-work-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.edit-work-required {
+  color: #c62828;
+}
+
+.edit-work-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.edit-work-cancel {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+}
+
+.edit-work-save {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  background-color: #396cd8;
+  color: #fff;
+  border-color: #396cd8;
+}
+
+.edit-work-save:hover:not(:disabled) {
+  background-color: #2c56b0;
+  border-color: #2c56b0;
+}
+
+.viewer-toolbar-separator {
+  color: #888;
+  margin: 0 4px;
+  user-select: none;
+}
+
+/* ============================
    Dark Mode
    ============================ */
 
@@ -2551,5 +2664,46 @@ button:disabled {
 
   .toast-close:hover {
     color: #f0f0f0;
+  }
+
+  .context-menu {
+    background: #3a3a3a;
+    border-color: #555;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .context-menu-item {
+    color: #ddd;
+  }
+
+  .context-menu-item:hover {
+    background: #4a4a4a;
+  }
+
+  .edit-work-dialog {
+    background: #3a3a3a;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
+
+  .edit-work-label {
+    color: #aaa;
+  }
+
+  .edit-work-required {
+    color: #ef5350;
+  }
+
+  .edit-work-save {
+    background-color: #396cd8;
+    border-color: #396cd8;
+  }
+
+  .edit-work-save:hover:not(:disabled) {
+    background-color: #2c56b0;
+    border-color: #2c56b0;
+  }
+
+  .viewer-toolbar-separator {
+    color: #666;
   }
 }

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  interface MenuItem {
+    label: string;
+    action: () => void;
+  }
+
+  interface Props {
+    x: number;
+    y: number;
+    items: MenuItem[];
+    onClose: () => void;
+  }
+
+  let { x, y, items, onClose }: Props = $props();
+
+  function handleWindowClick() {
+    onClose();
+  }
+</script>
+
+<svelte:window onclick={handleWindowClick} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="context-menu"
+  style="left: {x}px; top: {y}px;"
+  oncontextmenu={(e) => e.preventDefault()}
+>
+  {#each items as item, i (i)}
+    <button
+      class="context-menu-item"
+      onclick={(e) => {
+        e.stopPropagation();
+        item.action();
+      }}
+    >
+      {item.label}
+    </button>
+  {/each}
+</div>

--- a/src/lib/components/EditWorkDialog.svelte
+++ b/src/lib/components/EditWorkDialog.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { addToast } from "../stores/toast.svelte";
+  import type { WorkDetail } from "../types";
+
+  interface Props {
+    work: WorkDetail;
+    onClose: () => void;
+    onUpdated: (workId: number) => void;
+  }
+
+  let { work, onClose, onUpdated }: Props = $props();
+
+  let title = $state(work.title);
+  let artist = $state(work.artist ?? "");
+  let year = $state(work.year?.toString() ?? "");
+  let genre = $state(work.genre ?? "");
+  let circle = $state(work.circle ?? "");
+  let origin = $state(work.origin ?? "");
+  let saving = $state(false);
+
+  let canSave = $derived(title.trim().length > 0 && !saving);
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  function handleOverlayClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  }
+
+  async function handleSave() {
+    if (!canSave) return;
+    saving = true;
+    try {
+      const parsedYear = year.trim() ? parseInt(year.trim(), 10) : null;
+      if (parsedYear !== null && isNaN(parsedYear)) {
+        addToast("error", "年は数値で入力してください");
+        saving = false;
+        return;
+      }
+      await invoke("update_work", {
+        id: work.id,
+        title: title.trim(),
+        artist: artist.trim() || null,
+        year: parsedYear,
+        genre: genre.trim() || null,
+        circle: circle.trim() || null,
+        origin: origin.trim() || null,
+      });
+      addToast("success", "メタデータを更新しました");
+      onUpdated(work.id);
+      onClose();
+    } catch (e) {
+      addToast("error", `更新に失敗しました: ${e}`);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="edit-work-overlay" onmousedown={handleOverlayClick}>
+  <div class="edit-work-dialog">
+    <h3 class="edit-work-dialog-title">メタデータを編集</h3>
+    <div class="edit-work-form">
+      <label class="edit-work-label">
+        タイトル <span class="edit-work-required">*</span>
+        <input
+          class="settings-input"
+          type="text"
+          bind:value={title}
+          placeholder="タイトル"
+        />
+      </label>
+      <label class="edit-work-label">
+        アーティスト
+        <input
+          class="settings-input"
+          type="text"
+          bind:value={artist}
+          placeholder="アーティスト"
+        />
+      </label>
+      <label class="edit-work-label">
+        年
+        <input
+          class="settings-input"
+          type="number"
+          bind:value={year}
+          placeholder="年"
+        />
+      </label>
+      <label class="edit-work-label">
+        ジャンル
+        <input
+          class="settings-input"
+          type="text"
+          bind:value={genre}
+          placeholder="ジャンル"
+        />
+      </label>
+      <label class="edit-work-label">
+        サークル
+        <input
+          class="settings-input"
+          type="text"
+          bind:value={circle}
+          placeholder="サークル"
+        />
+      </label>
+      <label class="edit-work-label">
+        出典
+        <input
+          class="settings-input"
+          type="text"
+          bind:value={origin}
+          placeholder="出典"
+        />
+      </label>
+    </div>
+    <div class="edit-work-actions">
+      <button class="edit-work-cancel" onclick={onClose}>キャンセル</button>
+      <button class="edit-work-save" disabled={!canSave} onclick={handleSave}>
+        {saving ? "保存中..." : "保存"}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/WorkCard.svelte
+++ b/src/lib/components/WorkCard.svelte
@@ -18,9 +18,10 @@
   interface Props {
     work: WorkSummary;
     onclick: (workId: number) => void;
+    oncontextmenu?: (workId: number, e: MouseEvent) => void;
   }
 
-  let { work, onclick }: Props = $props();
+  let { work, onclick, oncontextmenu }: Props = $props();
   let thumbnailUrl = $state<string | null>(null);
   let loading = $state(true);
 
@@ -55,7 +56,16 @@
   });
 </script>
 
-<button class="work-card" onclick={() => onclick(work.id)}>
+<button
+  class="work-card"
+  onclick={() => onclick(work.id)}
+  oncontextmenu={(e) => {
+    if (oncontextmenu) {
+      e.preventDefault();
+      oncontextmenu(work.id, e);
+    }
+  }}
+>
   {#if loading}
     <div class="no-thumbnail"></div>
   {:else if thumbnailUrl}

--- a/src/lib/components/WorkGrid.svelte
+++ b/src/lib/components/WorkGrid.svelte
@@ -3,8 +3,11 @@
   import { VList } from "virtua/svelte";
   import WorkCardComponent from "./WorkCard.svelte";
   import { WorkCard } from "./WorkCard.svelte";
+  import ContextMenu from "./ContextMenu.svelte";
+  import EditWorkDialog from "./EditWorkDialog.svelte";
   import type {
     WorkSummary,
+    WorkDetail,
     SortField,
     SortOrder,
     Tag,
@@ -36,6 +39,10 @@
   let sortField = $state<SortField>("created_at");
   let sortOrder = $state<SortOrder>("desc");
   let containerWidth = $state(0);
+  let contextMenu = $state<{ x: number; y: number; workId: number } | null>(
+    null,
+  );
+  let editingWork = $state<WorkDetail | null>(null);
 
   const CARD_WIDTH = 180;
   const GAP = 16;
@@ -105,6 +112,20 @@
     void tagSearchMode;
     loadWorks();
   });
+
+  function handleContextMenu(workId: number, e: MouseEvent) {
+    contextMenu = { x: e.clientX, y: e.clientY, workId };
+  }
+
+  async function openEditDialog(workId: number) {
+    contextMenu = null;
+    try {
+      const detail: WorkDetail = await invoke("get_work", { workId });
+      editingWork = detail;
+    } catch (e) {
+      console.error("Failed to get work:", e);
+    }
+  }
 
   function handleSort(e: Event) {
     const value = (e.target as HTMLSelectElement).value;
@@ -179,7 +200,11 @@
           style="gap: {GAP}px; grid-template-columns: repeat({columnCount}, {CARD_WIDTH}px);"
         >
           {#each row as work (work.id)}
-            <WorkCardComponent {work} onclick={onSelectWork} />
+            <WorkCardComponent
+              {work}
+              onclick={onSelectWork}
+              oncontextmenu={handleContextMenu}
+            />
           {/each}
         </div>
       {/snippet}
@@ -193,3 +218,25 @@
     </div>
   {/if}
 </div>
+
+{#if contextMenu}
+  <ContextMenu
+    x={contextMenu.x}
+    y={contextMenu.y}
+    items={[
+      {
+        label: "メタデータを編集",
+        action: () => openEditDialog(contextMenu!.workId),
+      },
+    ]}
+    onClose={() => (contextMenu = null)}
+  />
+{/if}
+
+{#if editingWork}
+  <EditWorkDialog
+    work={editingWork}
+    onClose={() => (editingWork = null)}
+    onUpdated={() => loadWorks()}
+  />
+{/if}

--- a/src/lib/components/WorkViewer.svelte
+++ b/src/lib/components/WorkViewer.svelte
@@ -3,6 +3,7 @@
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import type { WorkDetail, FitMode, SlideshowMode, Tag } from "../types";
   import TagInput from "./TagInput.svelte";
+  import EditWorkDialog from "./EditWorkDialog.svelte";
 
   interface Props {
     workId: number;
@@ -38,6 +39,7 @@
   let tagInputFocused = $state(false);
   let workTags = $state<Tag[]>([]);
   let tagToRemove = $state<Tag | null>(null);
+  let showEditDialog = $state(false);
 
   let imageUrl = $derived(`sharaku://localhost/view/${workId}/${currentPage}`);
   let pageCount = $derived(work?.pageCount ?? 1);
@@ -209,6 +211,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
+    if (showEditDialog) return;
     if (tagToRemove) {
       if (e.key === "Escape") {
         tagToRemove = null;
@@ -371,6 +374,14 @@
         S
       </button>
       <span class="viewer-zoom-label">{Math.round(zoom * 100)}%</span>
+      <span class="viewer-toolbar-separator">|</span>
+      <button
+        class="viewer-fit-btn"
+        onclick={() => (showEditDialog = true)}
+        title="メタデータを編集"
+      >
+        Edit
+      </button>
     </div>
   </div>
 
@@ -552,5 +563,13 @@
         </div>
       </div>
     </div>
+  {/if}
+
+  {#if showEditDialog && work}
+    <EditWorkDialog
+      {work}
+      onClose={() => (showEditDialog = false)}
+      onUpdated={() => loadWork()}
+    />
   {/if}
 </div>


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/70

# 変更点

- 作品のメタデータ（タイトル、アーティスト、年、ジャンル、サークル、出典）を後から編集できるようにした
- 一覧画面で作品カードを右クリックするとコンテキストメニューが表示され、「メタデータを編集」を選択できる
- ビューアー画面のヘッダーツールバーに「Edit」ボタンを追加し、同様に編集ダイアログを開ける
- 汎用コンテキストメニューコンポーネント（ContextMenu）を新規作成し、将来の右クリックメニュー項目追加に対応
- バックエンドに `update_work` DB関数とTauriコマンドを追加（ユニットテスト3件含む）

# 備考

- DBスキーマの変更なし（既存カラムで対応）
- TypeScript型定義の変更なし（既存の `WorkDetail` / `WorkMetadata` を利用）
- EditWorkDialog の Escape キーは `stopPropagation` せず、`showEditDialog` フラグで WorkViewer のキーハンドラをスキップすることで競合を回避