### PR TITLE
worktree用のフック設定を追加

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name')
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel)
+WORKTREE_DIR="$REPO_ROOT/.worktrees/$NAME"
+
+cleanup() {
+    if [ -d "$WORKTREE_DIR" ]; then
+        git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    fi
+}
+trap cleanup ERR
+
+mkdir -p "$(dirname "$WORKTREE_DIR")"
+git -C "$REPO_ROOT" worktree add "$WORKTREE_DIR" >&2
+
+cd "$WORKTREE_DIR"
+npm install >&2
+
+echo "$WORKTREE_DIR"

--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+WORKTREE_PATH=$(echo "$INPUT" | jq -r '.worktree_path')
+
+MAIN_REPO=$(git -C "$WORKTREE_PATH" rev-parse --path-format=absolute --git-common-dir)
+MAIN_REPO="${MAIN_REPO%/.git}"
+
+git -C "$MAIN_REPO" worktree remove --force "$WORKTREE_PATH" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,11 +10,34 @@
       "Bash(cargo remove:*)",
       "Bash(rustfmt:*)",
       "Bash(scripts/screenshot.sh:*)",
-      "Bash(bash scripts/screenshot.sh:*)"
+      "Bash(bash scripts/screenshot.sh:*)",
+      "Bash(npm:*)"
     ],
     "ask": [
       "Bash(cargo install:*)",
       "Bash(cargo add:*)"
+    ]
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-create.sh\""
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-remove.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 
 # Claude Code
 .claude/settings.local.json
+.worktrees/


### PR DESCRIPTION
# 変更点

- WorktreeCreate / WorktreeRemove フックを `.claude/settings.json` に追加
- worktree作成時に `npm install` を自動実行する `worktree-create.sh` を追加
- worktree削除時にクリーンアップする `worktree-remove.sh` を追加
- `.gitignore` に `.worktrees/` を追加
- `Bash(npm:*)` を許可リストに追加

# 備考

- [Engram](https://github.com/TenTakano/Engram/blob/master/.claude/settings.json) の設定を参考に、Sharaku（npm + Tauri）に適応した構成