### PR TITLE
起動時パニックの修正とmacOSの開発データパス対応

### DIFF
--- a/scripts/reset-dev-data.sh
+++ b/scripts/reset-dev-data.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEV_DATA_DIR="$HOME/.local/share/com.sharaku.viewer.dev"
+case "$(uname)" in
+  Darwin) DEV_DATA_DIR="$HOME/Library/Application Support/com.sharaku.viewer.dev" ;;
+  *)      DEV_DATA_DIR="$HOME/.local/share/com.sharaku.viewer.dev" ;;
+esac
 
 if [ ! -d "$DEV_DATA_DIR" ]; then
   echo "Dev data directory does not exist: $DEV_DATA_DIR"

--- a/src-tauri/src/import_queue.rs
+++ b/src-tauri/src/import_queue.rs
@@ -55,7 +55,7 @@ pub struct ImportQueue {
 impl ImportQueue {
     pub fn new(app_handle: AppHandle, db: Arc<Mutex<AppDb>>) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        tokio::spawn(worker(rx, app_handle, db));
+        tauri::async_runtime::spawn(worker(rx, app_handle, db));
         Self { tx }
     }
 


### PR DESCRIPTION
# 変更点

- `ImportQueue::new` 内の `tokio::spawn` を `tauri::async_runtime::spawn` に変更し、Tauriの `setup` コールバック内でTokioランタイムが未初期化のため起動時にパニックする問題を修正
- `reset-dev-data.sh` のデータディレクトリパスをmacOS（`~/Library/Application Support/`）にも対応するよう修正

# 備考

- なし