### PR TITLE
単一作品でのビューアーループナビゲーションを修正

### DIFF
--- a/src/lib/components/WorkViewer.svelte
+++ b/src/lib/components/WorkViewer.svelte
@@ -140,8 +140,12 @@
       currentPage--;
     } else if (hasMultipleWorks && currentWorkIndex > 0) {
       navigateToWork(workIds[currentWorkIndex - 1]);
-    } else if (slideshowLoop && hasMultipleWorks) {
-      navigateToWork(workIds[totalWorks - 1]);
+    } else if (slideshowLoop) {
+      if (hasMultipleWorks) {
+        navigateToWork(workIds[totalWorks - 1]);
+      } else {
+        currentPage = pageCount - 1;
+      }
     }
   }
 
@@ -150,8 +154,12 @@
       currentPage++;
     } else if (hasMultipleWorks && currentWorkIndex < totalWorks - 1) {
       navigateToWork(workIds[currentWorkIndex + 1]);
-    } else if (slideshowLoop && hasMultipleWorks) {
-      navigateToWork(workIds[0]);
+    } else if (slideshowLoop) {
+      if (hasMultipleWorks) {
+        navigateToWork(workIds[0]);
+      } else {
+        currentPage = 0;
+      }
     }
   }
 


### PR DESCRIPTION
# 変更点

- `navigateNext()` / `navigatePrev()` のループ条件から `hasMultipleWorks` を分離し、作品が1つしかない場合でもループON時にページ間を循環できるようにした
- 複数作品がある場合の動作は従来通り（作品間をループ）

# 備考

- `advanceSlideshow()` は元から `hasMultipleWorks` チェックがなく正常動作しているため変更なし