### PR TITLE
コンテクストメニューから作品を削除する機能を追加

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -720,7 +720,11 @@ async fn search_works_by_tags(
 }
 
 #[tauri::command]
-async fn delete_work(state: tauri::State<'_, AppState>, work_id: i64) -> Result<(), String> {
+async fn delete_work(
+    state: tauri::State<'_, AppState>,
+    work_id: i64,
+    delete_files: bool,
+) -> Result<(), String> {
     let db = state.db.clone();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
@@ -728,6 +732,19 @@ async fn delete_work(state: tauri::State<'_, AppState>, work_id: i64) -> Result<
             .active_library
             .as_ref()
             .ok_or("ライブラリが選択されていません")?;
+
+        if delete_files {
+            let work = db::get_work(&guard.conn, work_id).map_err(|e| e.to_string())?;
+            let path = std::path::Path::new(&work.path);
+            if path.exists() {
+                if path.is_dir() {
+                    std::fs::remove_dir_all(path).map_err(|e| e.to_string())?;
+                } else {
+                    std::fs::remove_file(path).map_err(|e| e.to_string())?;
+                }
+            }
+        }
+
         db::delete_works_by_ids(&guard.conn, &active.id, &[work_id]).map_err(|e| e.to_string())?;
         Ok(())
     })

--- a/src/app.css
+++ b/src/app.css
@@ -2355,6 +2355,16 @@ button:disabled {
   line-height: 1.5;
 }
 
+.confirm-dialog-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+  font-size: 0.875rem;
+  color: #555;
+  cursor: pointer;
+}
+
 .confirm-dialog-actions {
   display: flex;
   justify-content: flex-end;
@@ -2994,6 +3004,10 @@ button:disabled {
   }
 
   .confirm-dialog-message {
+    color: #aaa;
+  }
+
+  .confirm-dialog-checkbox {
     color: #aaa;
   }
 

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from "svelte";
+
   interface Props {
     title: string;
     message: string;
@@ -6,6 +8,7 @@
     danger?: boolean;
     onConfirm: () => void;
     onCancel: () => void;
+    extra?: Snippet;
   }
 
   let {
@@ -15,6 +18,7 @@
     danger = false,
     onConfirm,
     onCancel,
+    extra,
   }: Props = $props();
 
   function handleKeydown(e: KeyboardEvent) {
@@ -38,6 +42,9 @@
   <div class="confirm-dialog">
     <h3 class="confirm-dialog-title">{title}</h3>
     <p class="confirm-dialog-message">{message}</p>
+    {#if extra}
+      {@render extra()}
+    {/if}
     <div class="confirm-dialog-actions">
       <button class="confirm-dialog-cancel" onclick={onCancel}>
         キャンセル

--- a/src/lib/components/WorkGrid.svelte
+++ b/src/lib/components/WorkGrid.svelte
@@ -46,6 +46,8 @@
   );
   let editingWork = $state<WorkDetail | null>(null);
   let deletingWork = $state<{ id: number; title: string } | null>(null);
+  let deleteFiles = $state(false);
+  let isFullMode = $state(false);
 
   const CARD_WIDTH = 180;
   const GAP = 16;
@@ -130,19 +132,25 @@
     }
   }
 
-  function openDeleteDialog(workId: number) {
+  async function openDeleteDialog(workId: number) {
     contextMenu = null;
     const work = works.find((w) => w.id === workId);
-    if (work) {
-      deletingWork = { id: work.id, title: work.title };
+    if (!work) return;
+    try {
+      const settings: { resourceMode: string } = await invoke("get_settings");
+      isFullMode = settings.resourceMode === "full";
+    } catch {
+      isFullMode = false;
     }
+    deleteFiles = false;
+    deletingWork = { id: work.id, title: work.title };
   }
 
   async function handleDelete() {
     if (!deletingWork) return;
     const { id, title } = deletingWork;
     try {
-      await invoke("delete_work", { workId: id });
+      await invoke("delete_work", { workId: id, deleteFiles });
       addToast("success", `「${title}」を削除しました`);
       deletingWork = null;
       loadWorks();
@@ -269,7 +277,16 @@
     danger={true}
     onConfirm={handleDelete}
     onCancel={() => (deletingWork = null)}
-  />
+  >
+    {#snippet extra()}
+      {#if isFullMode}
+        <label class="confirm-dialog-checkbox">
+          <input type="checkbox" bind:checked={deleteFiles} />
+          ローカルファイルも削除する
+        </label>
+      {/if}
+    {/snippet}
+  </ConfirmDialog>
 {/if}
 
 {#if editingWork}


### PR DESCRIPTION
# 変更点

- 作品を右クリック → コンテクストメニューに「削除」項目を追加
- 削除選択時に確認ダイアログを表示し、誤操作を防止
- 確認後にDBレコードを削除（ファイルシステム上の実ファイルは残す）
- 「すべてを管理」モードのライブラリでは「ローカルファイルも削除する」チェックボックスを表示
- 削除成功時にトースト通知を表示し、一覧を自動リロード
- 汎用の `ConfirmDialog` コンポーネントを新規作成（Escape/オーバーレイクリックでキャンセル可能、snippet slotで追加コンテンツ対応）

# 備考

- `works_tags` と `playlist_items` は ON DELETE CASCADE により自動削除される
- 複数選択による一括削除は今回のスコープ外