### PR TITLE
[92] フォルダ探索で最下層ディレクトリのみを作品候補とする

### DIFF
--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -247,6 +247,21 @@ pub struct DiscoveredFolder {
 }
 
 #[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SkippedFolder {
+    pub path: String,
+    pub folder_name: String,
+    pub image_count: usize,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    pub folders: Vec<DiscoveredFolder>,
+    pub skipped_folders: Vec<SkippedFolder>,
+}
+
+#[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum DiscoverProgress {
     Scanning { scanned_dirs: usize },
@@ -258,8 +273,8 @@ pub fn discover_image_folders(
     conn: &rusqlite::Connection,
     library_id: &str,
     on_progress: &Channel<DiscoverProgress>,
-) -> Result<Vec<DiscoveredFolder>, AppError> {
-    let mut folders = Vec::new();
+) -> Result<DiscoverResult, AppError> {
+    let mut candidates: Vec<(PathBuf, usize)> = Vec::new();
     let mut scanned_dirs = 0usize;
 
     for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
@@ -274,33 +289,17 @@ pub fn discover_image_folders(
 
         let dir_path = entry.path();
         let image_count = scanner::count_direct_images(dir_path);
-        if image_count == 0 {
-            continue;
+        if image_count > 0 {
+            candidates.push((dir_path.to_path_buf(), image_count));
         }
-
-        let folder_name = dir_path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-
-        let path_str = dir_path.to_string_lossy().to_string();
-        let already_registered = db::path_exists(conn, library_id, &path_str)?;
-        let parsed_metadata = parse_folder_name(&folder_name);
-
-        folders.push(DiscoveredFolder {
-            path: path_str,
-            folder_name,
-            image_count,
-            parsed_metadata,
-            already_registered,
-        });
     }
 
+    let result = partition_leaf_folders(&candidates, conn, library_id, &[root])?;
+
     let _ = on_progress.send(DiscoverProgress::Completed {
-        found: folders.len(),
+        found: result.folders.len(),
     });
-    Ok(folders)
+    Ok(result)
 }
 
 pub fn discover_from_paths(
@@ -308,8 +307,8 @@ pub fn discover_from_paths(
     conn: &rusqlite::Connection,
     library_id: &str,
     on_progress: &Channel<DiscoverProgress>,
-) -> Result<Vec<DiscoveredFolder>, AppError> {
-    let mut folders = Vec::new();
+) -> Result<DiscoverResult, AppError> {
+    let mut candidates: Vec<(PathBuf, usize)> = Vec::new();
     let mut seen_paths = HashSet::new();
     let mut scanned_dirs = 0usize;
 
@@ -327,38 +326,93 @@ pub fn discover_from_paths(
             let dir_path = entry.path();
             let path_str = dir_path.to_string_lossy().to_string();
 
-            if !seen_paths.insert(path_str.clone()) {
+            if !seen_paths.insert(path_str) {
                 continue;
             }
 
             let image_count = scanner::count_direct_images(dir_path);
-            if image_count == 0 {
-                continue;
+            if image_count > 0 {
+                candidates.push((dir_path.to_path_buf(), image_count));
             }
+        }
+    }
 
-            let folder_name = dir_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
+    let root_refs: Vec<&Path> = roots.iter().map(|r| r.as_path()).collect();
+    let result = partition_leaf_folders(&candidates, conn, library_id, &root_refs)?;
 
+    let _ = on_progress.send(DiscoverProgress::Completed {
+        found: result.folders.len(),
+    });
+    Ok(result)
+}
+
+fn find_leaf_indices(candidates: &[(PathBuf, usize)], roots: &[&Path]) -> HashSet<usize> {
+    let root_set: HashSet<&Path> = roots.iter().copied().collect();
+    let mut parent_of_image_dir = HashSet::new();
+    for (path, _) in candidates {
+        let mut ancestor = path.parent();
+        while let Some(a) = ancestor {
+            if !parent_of_image_dir.insert(a.to_path_buf()) {
+                break;
+            }
+            if root_set.contains(a) {
+                break;
+            }
+            ancestor = a.parent();
+        }
+    }
+
+    candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, (path, _))| !parent_of_image_dir.contains(path))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn partition_leaf_folders(
+    candidates: &[(PathBuf, usize)],
+    conn: &rusqlite::Connection,
+    library_id: &str,
+    roots: &[&Path],
+) -> Result<DiscoverResult, AppError> {
+    let leaf_indices = find_leaf_indices(candidates, roots);
+
+    let mut folders = Vec::new();
+    let mut skipped_folders = Vec::new();
+
+    for (i, (path, image_count)) in candidates.iter().enumerate() {
+        let folder_name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        if leaf_indices.contains(&i) {
+            let path_str = path.to_string_lossy().to_string();
             let already_registered = db::path_exists(conn, library_id, &path_str)?;
             let parsed_metadata = parse_folder_name(&folder_name);
 
             folders.push(DiscoveredFolder {
                 path: path_str,
                 folder_name,
-                image_count,
+                image_count: *image_count,
                 parsed_metadata,
                 already_registered,
+            });
+        } else {
+            skipped_folders.push(SkippedFolder {
+                path: path.to_string_lossy().to_string(),
+                folder_name,
+                image_count: *image_count,
             });
         }
     }
 
-    let _ = on_progress.send(DiscoverProgress::Completed {
-        found: folders.len(),
-    });
-    Ok(folders)
+    Ok(DiscoverResult {
+        folders,
+        skipped_folders,
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,7 +20,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use db::{Tag, WorkDetail, WorkSummary};
 use import_queue::{ImportJob, ImportQueue, ImportQueueEvent};
-use importer::{DiscoverProgress, DiscoveredFolder, ParsedMetadata};
+use importer::{DiscoverProgress, DiscoverResult, ParsedMetadata};
 use integrity::{IntegrityCheckProgress, IntegrityReport};
 use library::Library;
 use relocator::{RelocationPreview, RelocationProgress};
@@ -473,7 +473,7 @@ async fn discover_folders(
     state: tauri::State<'_, AppState>,
     root_path: String,
     on_progress: tauri::ipc::Channel<DiscoverProgress>,
-) -> Result<Vec<DiscoveredFolder>, String> {
+) -> Result<DiscoverResult, String> {
     let db = state.db.clone();
     let root = PathBuf::from(root_path);
     tokio::task::spawn_blocking(move || {
@@ -494,7 +494,7 @@ async fn discover_dropped_paths(
     state: tauri::State<'_, AppState>,
     paths: Vec<String>,
     on_progress: tauri::ipc::Channel<DiscoverProgress>,
-) -> Result<Vec<DiscoveredFolder>, String> {
+) -> Result<DiscoverResult, String> {
     let db = state.db.clone();
     let roots: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
     tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/tests/importer.rs
+++ b/src-tauri/src/tests/importer.rs
@@ -263,10 +263,7 @@ fn leaf_indices_multiple_independent_roots() {
         (PathBuf::from("/root_b/work1"), 3),
         (PathBuf::from("/root_b/work2"), 4),
     ];
-    let leaves = find_leaf_indices(
-        &candidates,
-        &[Path::new("/root_a"), Path::new("/root_b")],
-    );
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root_a"), Path::new("/root_b")]);
     assert_eq!(leaves.len(), 3);
     assert!(leaves.contains(&1)); // root_a/child
     assert!(leaves.contains(&2)); // root_b/work1

--- a/src-tauri/src/tests/importer.rs
+++ b/src-tauri/src/tests/importer.rs
@@ -185,6 +185,95 @@ fn list_images_natural_sort_order() {
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
+// find_leaf_indices tests
+
+#[test]
+fn leaf_indices_flat_structure() {
+    let candidates = vec![
+        (PathBuf::from("/root/work1"), 3),
+        (PathBuf::from("/root/work2"), 5),
+    ];
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root")]);
+    assert_eq!(leaves.len(), 2);
+    assert!(leaves.contains(&0));
+    assert!(leaves.contains(&1));
+}
+
+#[test]
+fn leaf_indices_nested_skips_intermediate() {
+    let candidates = vec![
+        (PathBuf::from("/root"), 1),
+        (PathBuf::from("/root/chapter1"), 3),
+        (PathBuf::from("/root/chapter2"), 5),
+    ];
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root")]);
+    assert_eq!(leaves.len(), 2);
+    assert!(leaves.contains(&1));
+    assert!(leaves.contains(&2));
+    assert!(!leaves.contains(&0));
+}
+
+#[test]
+fn leaf_indices_deeply_nested() {
+    let candidates = vec![
+        (PathBuf::from("/root"), 1),
+        (PathBuf::from("/root/level1"), 2),
+        (PathBuf::from("/root/level1/level2"), 3),
+    ];
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root")]);
+    assert_eq!(leaves.len(), 1);
+    assert!(leaves.contains(&2));
+}
+
+#[test]
+fn leaf_indices_single_leaf() {
+    let candidates = vec![(PathBuf::from("/root"), 5)];
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root")]);
+    assert_eq!(leaves.len(), 1);
+    assert!(leaves.contains(&0));
+}
+
+#[test]
+fn leaf_indices_mixed_branches() {
+    // root/
+    //   cover.jpg         <- intermediate (has child with images)
+    //   branch_a/
+    //     page.jpg         <- leaf
+    //   branch_b/
+    //     page.jpg         <- intermediate
+    //     sub/
+    //       page.jpg       <- leaf
+    let candidates = vec![
+        (PathBuf::from("/root"), 1),
+        (PathBuf::from("/root/branch_a"), 1),
+        (PathBuf::from("/root/branch_b"), 1),
+        (PathBuf::from("/root/branch_b/sub"), 1),
+    ];
+    let leaves = find_leaf_indices(&candidates, &[Path::new("/root")]);
+    assert_eq!(leaves.len(), 2);
+    assert!(leaves.contains(&1)); // branch_a
+    assert!(leaves.contains(&3)); // branch_b/sub
+}
+
+#[test]
+fn leaf_indices_multiple_independent_roots() {
+    let candidates = vec![
+        (PathBuf::from("/root_a"), 1),
+        (PathBuf::from("/root_a/child"), 2),
+        (PathBuf::from("/root_b/work1"), 3),
+        (PathBuf::from("/root_b/work2"), 4),
+    ];
+    let leaves = find_leaf_indices(
+        &candidates,
+        &[Path::new("/root_a"), Path::new("/root_b")],
+    );
+    assert_eq!(leaves.len(), 3);
+    assert!(leaves.contains(&1)); // root_a/child
+    assert!(leaves.contains(&2)); // root_b/work1
+    assert!(leaves.contains(&3)); // root_b/work2
+    assert!(!leaves.contains(&0)); // root_a is intermediate
+}
+
 // count_direct_images tests
 
 #[test]

--- a/src/app.css
+++ b/src/app.css
@@ -1439,6 +1439,46 @@ button:disabled {
   margin: 0 0 8px;
 }
 
+.bulk-skipped-warning {
+  background: #fff3e0;
+  border-left: 4px solid #e65100;
+  padding: 12px 16px;
+  margin: 0 0 16px;
+  border-radius: 4px;
+}
+
+.bulk-skipped-message {
+  font-size: 0.875rem;
+  color: #e65100;
+  margin: 0;
+}
+
+.bulk-skipped-toggle {
+  background: none;
+  border: none;
+  color: #e65100;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  padding: 4px 0;
+  text-decoration: underline;
+}
+
+.bulk-skipped-list {
+  font-size: 0.8125rem;
+  margin: 8px 0 0;
+  padding-left: 20px;
+}
+
+.bulk-skipped-list li {
+  margin-bottom: 4px;
+}
+
+.bulk-skipped-path {
+  color: #888;
+  margin-left: 8px;
+  font-size: 0.75rem;
+}
+
 .bulk-review-content progress,
 .import-content progress {
   width: 100%;
@@ -2810,6 +2850,23 @@ button:disabled {
 
   .bulk-progress-text {
     color: #aaa;
+  }
+
+  .bulk-skipped-warning {
+    background: #3d2800;
+    border-left-color: #ff9800;
+  }
+
+  .bulk-skipped-message {
+    color: #ffb74d;
+  }
+
+  .bulk-skipped-toggle {
+    color: #ffb74d;
+  }
+
+  .bulk-skipped-path {
+    color: #777;
   }
 
   .bulk-review-content progress::-webkit-progress-bar,

--- a/src/lib/components/BulkImportView.svelte
+++ b/src/lib/components/BulkImportView.svelte
@@ -6,13 +6,15 @@
   import type {
     AppSettings,
     ResourceMode,
-    DiscoveredFolder,
+    DiscoverResult,
     DiscoverProgress,
     ImportMode,
     ImportRequest,
     EnqueueResult,
     UnregisteredEntry,
     ParsedMetadata,
+    SkippedFolder,
+    DiscoveredFolder,
   } from "../types";
 
   interface Props {
@@ -32,6 +34,8 @@
   let discovering = $state(false);
   let discoverStatus = $state("");
   let folders = $state<DiscoveredFolder[]>([]);
+  let skippedFolders = $state<SkippedFolder[]>([]);
+  let showSkippedDetails = $state(false);
   let selected = new SvelteSet<number>();
   let editedTitles = new SvelteMap<number, string>();
   let editedArtists = new SvelteMap<number, string>();
@@ -52,11 +56,13 @@
     };
 
     try {
-      const result = await invoke<DiscoveredFolder[]>("discover_folders", {
+      const result = await invoke<DiscoverResult>("discover_folders", {
         rootPath,
         onProgress: channel,
       });
-      folders = result;
+      folders = result.folders;
+      skippedFolders = result.skippedFolders;
+      showSkippedDetails = false;
       selected.clear();
       folders.forEach((f, i) => {
         if (!f.alreadyRegistered) {
@@ -87,14 +93,13 @@
     };
 
     try {
-      const result = await invoke<DiscoveredFolder[]>(
-        "discover_dropped_paths",
-        {
-          paths,
-          onProgress: channel,
-        },
-      );
-      folders = result;
+      const result = await invoke<DiscoverResult>("discover_dropped_paths", {
+        paths,
+        onProgress: channel,
+      });
+      folders = result.folders;
+      skippedFolders = result.skippedFolders;
+      showSkippedDetails = false;
       selected.clear();
       folders.forEach((f, i) => {
         if (!f.alreadyRegistered) {
@@ -180,6 +185,8 @@
   function resetToDiscover() {
     step = "discover";
     folders = [];
+    skippedFolders = [];
+    showSkippedDetails = false;
     selected.clear();
     editedTitles.clear();
     editedArtists.clear();
@@ -249,6 +256,34 @@
       <p class="import-description">
         {folders.length} フォルダ検出 / {selected.size} 件選択中
       </p>
+
+      {#if skippedFolders.length > 0}
+        {@const skippedImageCount = skippedFolders.reduce(
+          (sum, f) => sum + f.imageCount,
+          0,
+        )}
+        <div class="bulk-skipped-warning">
+          <p class="bulk-skipped-message">
+            {skippedFolders.length} 件の中間フォルダにある {skippedImageCount} 枚の画像はスキップされました。最下層フォルダのみが作品として取り込まれます。
+          </p>
+          <button
+            class="bulk-skipped-toggle"
+            onclick={() => (showSkippedDetails = !showSkippedDetails)}
+          >
+            {showSkippedDetails ? "詳細を隠す" : "詳細を表示"}
+          </button>
+          {#if showSkippedDetails}
+            <ul class="bulk-skipped-list">
+              {#each skippedFolders as sf (sf.path)}
+                <li>
+                  {sf.folderName}（{sf.imageCount} 枚）
+                  <span class="bulk-skipped-path">{sf.path}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/if}
 
       <div class="bulk-toolbar">
         <label class="bulk-select-all">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,6 +121,17 @@ export interface DiscoveredFolder {
   alreadyRegistered: boolean;
 }
 
+export interface SkippedFolder {
+  path: string;
+  folderName: string;
+  imageCount: number;
+}
+
+export interface DiscoverResult {
+  folders: DiscoveredFolder[];
+  skippedFolders: SkippedFolder[];
+}
+
 export type DiscoverProgress =
   | { type: "scanning"; scannedDirs: number }
   | { type: "completed"; found: number };


### PR DESCRIPTION
# Issue

https://github.com/TenTakano/Sharaku/issues/92

# 変更点

- フォルダ探索（`discover_image_folders` / `discover_from_paths`）で、画像を含むサブディレクトリを持たない最下層ディレクトリのみを作品候補として返すように変更
- 中間ディレクトリに直接置かれた画像はスキップし、BulkImportView に警告バナーを表示（スキップされたフォルダ数・画像枚数を表示、折りたたみで詳細確認可能）
- リーフ判定ロジック（`find_leaf_indices`）を DB 非依存の純粋関数として切り出し、テスト6件を追加

# 備考

- 単一ディレクトリドロップで `has_image_subfolders` が false の場合（＝最下層そのもの）は従来通り ImportView に遷移するため影響なし
- `loadFromEntries`（整合性チェック由来）パスは discovery を経由しないため影響なし
