### PR TITLE
[#164] 単体画像ファイルを1つの作品としてインポートできるようにする

### DIFF
--- a/src-tauri/src/import_queue.rs
+++ b/src-tauri/src/import_queue.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
 
 use crate::error::AppError;
-use crate::importer::{self, ImportRequest};
+use crate::importer::{self, ImportKind, ImportRequest};
 use crate::settings;
 use crate::AppDb;
 
@@ -115,7 +115,14 @@ async fn worker(
                         Path::new("")
                     }
                 };
-                importer::import_work(&request, &guard.conn, &library_id, lib_root)
+                match request.kind {
+                    ImportKind::Folder => {
+                        importer::import_work(&request, &guard.conn, &library_id, lib_root)
+                    }
+                    ImportKind::Image => {
+                        importer::import_single_image(&request, &guard.conn, &library_id, lib_root)
+                    }
+                }
             })
             .await;
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -23,6 +23,8 @@ pub struct ImportRequest {
     pub circle: Option<String>,
     pub origin: Option<String>,
     pub mode: ImportMode,
+    #[serde(default)]
+    pub kind: ImportKind,
 }
 
 #[derive(Serialize)]
@@ -44,6 +46,23 @@ pub struct ParsedMetadata {
 pub enum ImportMode {
     Copy,
     Move,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum ImportKind {
+    #[default]
+    Folder,
+    Image,
+}
+
+impl ImportKind {
+    pub fn work_kind(self) -> &'static str {
+        match self {
+            ImportKind::Folder => template::WORK_KIND_FOLDER,
+            ImportKind::Image => template::WORK_KIND_IMAGE,
+        }
+    }
 }
 
 pub fn parse_folder_name(folder_name: &str) -> ParsedMetadata {
@@ -97,8 +116,9 @@ pub fn preview_import_path(
     library_root: &Path,
     template_str: &str,
     metadata: &WorkMetadata,
+    work_kind: &str,
 ) -> String {
-    let path = template::resolve_work_path(library_root, template_str, metadata);
+    let path = template::resolve_work_path(library_root, template_str, metadata, work_kind);
     path.to_string_lossy().to_string()
 }
 
@@ -167,7 +187,12 @@ pub fn import_work(
         work_type: Some(type_label),
     };
 
-    let dest = template::resolve_unique_work_path(library_root, &template_str, &metadata);
+    let dest = template::resolve_unique_work_path(
+        library_root,
+        &template_str,
+        &metadata,
+        template::WORK_KIND_FOLDER,
+    );
 
     if paths_overlap(source, &dest) {
         return Err(AppError::ImportError(
@@ -236,6 +261,124 @@ fn copy_images_to_dest(images: &[PathBuf], dest: &Path) -> Result<(), AppError> 
     Ok(())
 }
 
+pub fn import_single_image(
+    request: &ImportRequest,
+    conn: &rusqlite::Connection,
+    library_id: &str,
+    library_root: &Path,
+) -> Result<ImportResult, AppError> {
+    let source = Path::new(&request.source_path);
+    if !source.is_file() || !scanner::is_image_file(source) {
+        return Err(AppError::ImportError(
+            "ソースパスが画像ファイルではありません".to_string(),
+        ));
+    }
+
+    let resource_mode = settings::get_resource_mode(conn, library_id)?;
+    let thumb = thumbnail::generate_thumbnail(source)?;
+
+    if resource_mode == "metadata_only" {
+        let source_str = source.to_string_lossy().to_string();
+
+        db::insert_work(
+            conn,
+            &WorkRecord {
+                library_id,
+                title: &request.title,
+                path: &source_str,
+                work_type: "image",
+                page_count: 1,
+                thumbnail: &thumb,
+                artist: request.artist.as_deref(),
+                year: request.year,
+                genre: request.genre.as_deref(),
+                circle: request.circle.as_deref(),
+                origin: request.origin.as_deref(),
+            },
+        )?;
+
+        return Ok(ImportResult {
+            destination_path: source_str,
+            page_count: 1,
+        });
+    }
+
+    let template_str = settings::get_directory_template(conn, library_id)?.ok_or_else(|| {
+        AppError::ImportError("ディレクトリテンプレートが設定されていません".to_string())
+    })?;
+
+    let type_label = settings::resolve_type_label(conn, library_id, "image")?;
+    let metadata = WorkMetadata {
+        title: request.title.clone(),
+        artist: request.artist.clone(),
+        year: request.year,
+        genre: request.genre.clone(),
+        circle: request.circle.clone(),
+        origin: request.origin.clone(),
+        work_type: Some(type_label),
+    };
+
+    let dest_dir = template::resolve_unique_work_path(
+        library_root,
+        &template_str,
+        &metadata,
+        template::WORK_KIND_IMAGE,
+    );
+
+    if paths_overlap(source, &dest_dir) {
+        return Err(AppError::ImportError(
+            "取り込み元と取り込み先が重複しています".to_string(),
+        ));
+    }
+
+    let file_name = source
+        .file_name()
+        .ok_or_else(|| AppError::ImportError("無効なファイル名".to_string()))?;
+    let dest_file = dest_dir.join(file_name);
+
+    std::fs::create_dir_all(&dest_dir)?;
+
+    let rollback = |dest_dir: &Path| {
+        let _ = std::fs::remove_dir_all(dest_dir);
+    };
+
+    if let Err(e) = std::fs::copy(source, &dest_file) {
+        rollback(&dest_dir);
+        return Err(AppError::Io(e));
+    }
+
+    let dest_str = dest_file.to_string_lossy().to_string();
+
+    if let Err(e) = db::insert_work(
+        conn,
+        &WorkRecord {
+            library_id,
+            title: &request.title,
+            path: &dest_str,
+            work_type: "image",
+            page_count: 1,
+            thumbnail: &thumb,
+            artist: request.artist.as_deref(),
+            year: request.year,
+            genre: request.genre.as_deref(),
+            circle: request.circle.as_deref(),
+            origin: request.origin.as_deref(),
+        },
+    ) {
+        rollback(&dest_dir);
+        return Err(e);
+    }
+
+    if request.mode == ImportMode::Move {
+        let _ = std::fs::remove_file(source);
+    }
+
+    Ok(ImportResult {
+        destination_path: dest_str,
+        page_count: 1,
+    })
+}
+
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoveredFolder {
@@ -256,8 +399,18 @@ pub struct SkippedFolder {
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct DiscoveredImage {
+    pub path: String,
+    pub file_name: String,
+    pub parsed_metadata: ParsedMetadata,
+    pub already_registered: bool,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DiscoverResult {
     pub folders: Vec<DiscoveredFolder>,
+    pub images: Vec<DiscoveredImage>,
     pub skipped_folders: Vec<SkippedFolder>,
 }
 
@@ -311,8 +464,37 @@ pub fn discover_from_paths(
     let mut candidates: Vec<(PathBuf, usize)> = Vec::new();
     let mut seen_paths = HashSet::new();
     let mut scanned_dirs = 0usize;
+    let mut image_entries: Vec<DiscoveredImage> = Vec::new();
+    let mut seen_image_paths = HashSet::new();
+    let mut dir_roots: Vec<PathBuf> = Vec::new();
 
     for root in roots {
+        if root.is_file() && scanner::is_image_file(root) {
+            let path_str = root.to_string_lossy().to_string();
+            if !seen_image_paths.insert(path_str.clone()) {
+                continue;
+            }
+            let file_name = root
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let parsed_metadata = parse_image_file_name(&file_name);
+            let already_registered = db::path_exists(conn, library_id, &path_str)?;
+            image_entries.push(DiscoveredImage {
+                path: path_str,
+                file_name,
+                parsed_metadata,
+                already_registered,
+            });
+            continue;
+        }
+
+        if !root.is_dir() {
+            continue;
+        }
+
+        dir_roots.push(root.clone());
         for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
             if !entry.file_type().is_dir() {
                 continue;
@@ -337,13 +519,22 @@ pub fn discover_from_paths(
         }
     }
 
-    let root_refs: Vec<&Path> = roots.iter().map(|r| r.as_path()).collect();
-    let result = partition_leaf_folders(&candidates, conn, library_id, &root_refs)?;
+    let root_refs: Vec<&Path> = dir_roots.iter().map(|r| r.as_path()).collect();
+    let mut result = partition_leaf_folders(&candidates, conn, library_id, &root_refs)?;
+    result.images = image_entries;
 
     let _ = on_progress.send(DiscoverProgress::Completed {
-        found: result.folders.len(),
+        found: result.folders.len() + result.images.len(),
     });
     Ok(result)
+}
+
+pub fn parse_image_file_name(file_name: &str) -> ParsedMetadata {
+    let stem = Path::new(file_name)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file_name);
+    parse_folder_name(stem)
 }
 
 fn find_leaf_indices(candidates: &[(PathBuf, usize)], roots: &[&Path]) -> HashSet<usize> {
@@ -411,6 +602,7 @@ fn partition_leaf_folders(
 
     Ok(DiscoverResult {
         folders,
+        images: Vec::new(),
         skipped_folders,
     })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,7 +20,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use db::{Tag, WorkDetail, WorkSummary};
 use import_queue::{ImportJob, ImportQueue, ImportQueueEvent};
-use importer::{DiscoverProgress, DiscoverResult, ParsedMetadata};
+use importer::{DiscoverProgress, DiscoverResult, ImportKind, ParsedMetadata};
 use integrity::{IntegrityCheckProgress, IntegrityReport};
 use library::Library;
 use relocator::{RelocationPreview, RelocationProgress};
@@ -367,25 +367,6 @@ async fn has_image_subfolders(dir: String) -> Result<bool, String> {
 }
 
 #[tauri::command]
-async fn resolve_drop_path(path: String) -> Result<String, String> {
-    let p = std::path::Path::new(&path);
-    let folder = if p.is_dir() {
-        p.to_path_buf()
-    } else {
-        p.parent()
-            .ok_or_else(|| "親ディレクトリを取得できません".to_string())?
-            .to_path_buf()
-    };
-    if !folder.is_dir() {
-        return Err("有効なディレクトリではありません".to_string());
-    }
-    folder
-        .to_str()
-        .map(|s| s.to_string())
-        .ok_or_else(|| "パスの変換に失敗しました".to_string())
-}
-
-#[tauri::command]
 async fn parse_folder_name(folder_name: String) -> Result<ParsedMetadata, String> {
     Ok(importer::parse_folder_name(&folder_name))
 }
@@ -394,8 +375,10 @@ async fn parse_folder_name(folder_name: String) -> Result<ParsedMetadata, String
 async fn preview_import_path(
     state: tauri::State<'_, AppState>,
     metadata: WorkMetadata,
+    kind: Option<ImportKind>,
 ) -> Result<String, String> {
     let db = state.db.clone();
+    let kind = kind.unwrap_or_default();
     tokio::task::spawn_blocking(move || {
         let guard = db.lock().unwrap();
         let active = guard
@@ -413,10 +396,17 @@ async fn preview_import_path(
             lib_path,
             &template_str,
             &metadata,
+            kind.work_kind(),
         ))
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn classify_drop_path(path: String) -> Result<scanner::DropKind, String> {
+    let p = std::path::Path::new(&path);
+    Ok(scanner::classify_path(p))
 }
 
 #[derive(Serialize)]
@@ -1066,7 +1056,7 @@ pub fn run() {
             validate_template,
             preview_template,
             has_image_subfolders,
-            resolve_drop_path,
+            classify_drop_path,
             parse_folder_name,
             preview_import_path,
             enqueue_import,

--- a/src-tauri/src/relocator.rs
+++ b/src-tauri/src/relocator.rs
@@ -62,7 +62,12 @@ fn compute_relocation_plan(
 
     for work in works {
         let metadata = work_detail_to_metadata(work, type_label);
-        let base_path = template::resolve_work_path(library_root, new_template, &metadata);
+        let base_path = template::resolve_work_path(
+            library_root,
+            new_template,
+            &metadata,
+            template::WORK_KIND_FOLDER,
+        );
         let base_str = base_path.to_string_lossy().to_string();
 
         let new_path =

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -1,13 +1,33 @@
 use std::path::Path;
+
+use serde::Serialize;
 use walkdir::WalkDir;
 
 pub(crate) const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp"];
+
+#[derive(Serialize, Clone, Copy, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DropKind {
+    Folder,
+    Image,
+    Other,
+}
 
 pub(crate) fn is_image_file(path: &Path) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
         .map(|ext| IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()))
         .unwrap_or(false)
+}
+
+pub(crate) fn classify_path(path: &Path) -> DropKind {
+    if path.is_dir() {
+        DropKind::Folder
+    } else if path.is_file() && is_image_file(path) {
+        DropKind::Image
+    } else {
+        DropKind::Other
+    }
 }
 
 pub(crate) fn count_direct_images(dir: &Path) -> usize {

--- a/src-tauri/src/template.rs
+++ b/src-tauri/src/template.rs
@@ -9,6 +9,19 @@ const KNOWN_PLACEHOLDERS: &[&str] = &[
 ];
 const FORBIDDEN_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
 
+pub const WORK_KIND_FOLDER: &str = "folder";
+pub const WORK_KIND_IMAGE: &str = "image";
+
+const TOP_LEVEL_FOLDER: &str = "works";
+const TOP_LEVEL_IMAGE: &str = "pictures";
+
+pub fn top_level_for(work_kind: &str) -> &'static str {
+    match work_kind {
+        WORK_KIND_IMAGE => TOP_LEVEL_IMAGE,
+        _ => TOP_LEVEL_FOLDER,
+    }
+}
+
 #[derive(Deserialize)]
 pub struct WorkMetadata {
     pub title: String,
@@ -142,9 +155,14 @@ pub fn render_template(template: &str, metadata: &WorkMetadata) -> String {
         .join("/")
 }
 
-pub fn resolve_work_path(library_root: &Path, template: &str, metadata: &WorkMetadata) -> PathBuf {
+pub fn resolve_work_path(
+    library_root: &Path,
+    template: &str,
+    metadata: &WorkMetadata,
+    work_kind: &str,
+) -> PathBuf {
     let rendered = render_template(template, metadata);
-    let resolved = library_root.join(&rendered);
+    let resolved = library_root.join(top_level_for(work_kind)).join(&rendered);
     let normalized = normalize_path(&resolved);
     let root_normalized = normalize_path(library_root);
     if !normalized.starts_with(&root_normalized) {
@@ -172,8 +190,9 @@ pub fn resolve_unique_work_path(
     library_root: &Path,
     template: &str,
     metadata: &WorkMetadata,
+    work_kind: &str,
 ) -> PathBuf {
-    let base = resolve_work_path(library_root, template, metadata);
+    let base = resolve_work_path(library_root, template, metadata, work_kind);
     if !base.exists() {
         return base;
     }

--- a/src-tauri/src/tests/importer.rs
+++ b/src-tauri/src/tests/importer.rs
@@ -126,8 +126,33 @@ fn preview_path_with_template() {
         origin: None,
         work_type: None,
     };
-    let result = preview_import_path(Path::new("/library"), "{artist}/{title}", &metadata);
-    assert_eq!(result, "/library/Artist/My Work");
+    let result = preview_import_path(
+        Path::new("/library"),
+        "{artist}/{title}",
+        &metadata,
+        crate::template::WORK_KIND_FOLDER,
+    );
+    assert_eq!(result, "/library/works/Artist/My Work");
+}
+
+#[test]
+fn preview_path_for_image_kind() {
+    let metadata = WorkMetadata {
+        title: "Sketch".to_string(),
+        artist: Some("Artist".to_string()),
+        year: None,
+        genre: None,
+        circle: None,
+        origin: None,
+        work_type: None,
+    };
+    let result = preview_import_path(
+        Path::new("/library"),
+        "{artist}/{title}",
+        &metadata,
+        crate::template::WORK_KIND_IMAGE,
+    );
+    assert_eq!(result, "/library/pictures/Artist/Sketch");
 }
 
 // paths_overlap tests
@@ -299,6 +324,97 @@ fn count_direct_images_empty_dir() {
     std::fs::create_dir_all(&dir).unwrap();
 
     assert_eq!(crate::scanner::count_direct_images(&dir), 0);
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+// parse_image_file_name tests
+
+#[test]
+fn parse_image_file_name_strips_extension() {
+    let result = parse_image_file_name("[Artist] Work.jpg");
+    assert_eq!(result.title, "Work");
+    assert_eq!(result.artist.as_deref(), Some("Artist"));
+}
+
+#[test]
+fn parse_image_file_name_no_extension() {
+    let result = parse_image_file_name("plain_name");
+    assert_eq!(result.title, "plain_name");
+    assert_eq!(result.artist, None);
+}
+
+#[test]
+fn parse_image_file_name_multi_dot() {
+    let result = parse_image_file_name("Artist - Title.v2.png");
+    assert_eq!(result.title, "Title.v2");
+    assert_eq!(result.artist.as_deref(), Some("Artist"));
+}
+
+// import_single_image error cases
+
+#[test]
+fn import_single_image_rejects_non_image_file() {
+    let dir = std::env::temp_dir().join("sharaku_test_import_single_non_image");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let txt = dir.join("note.txt");
+    std::fs::write(&txt, b"text").unwrap();
+
+    let conn = crate::db::open_db_in_memory().unwrap();
+    crate::library::add_library(&conn, "Test", Some("/tmp")).ok();
+
+    let request = ImportRequest {
+        source_path: txt.to_string_lossy().to_string(),
+        title: "x".into(),
+        artist: None,
+        year: None,
+        genre: None,
+        circle: None,
+        origin: None,
+        mode: ImportMode::Copy,
+        kind: ImportKind::Image,
+    };
+
+    let lib_id = {
+        let mut stmt = conn.prepare("SELECT id FROM libraries LIMIT 1").unwrap();
+        stmt.query_row([], |row| row.get::<_, String>(0)).unwrap()
+    };
+
+    let result = import_single_image(&request, &conn, &lib_id, &dir);
+    assert!(result.is_err());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn import_single_image_rejects_directory_path() {
+    let dir = std::env::temp_dir().join("sharaku_test_import_single_dir_reject");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let conn = crate::db::open_db_in_memory().unwrap();
+    crate::library::add_library(&conn, "Test", Some("/tmp")).ok();
+
+    let request = ImportRequest {
+        source_path: dir.to_string_lossy().to_string(),
+        title: "x".into(),
+        artist: None,
+        year: None,
+        genre: None,
+        circle: None,
+        origin: None,
+        mode: ImportMode::Copy,
+        kind: ImportKind::Image,
+    };
+
+    let lib_id = {
+        let mut stmt = conn.prepare("SELECT id FROM libraries LIMIT 1").unwrap();
+        stmt.query_row([], |row| row.get::<_, String>(0)).unwrap()
+    };
+
+    let result = import_single_image(&request, &conn, &lib_id, &dir);
+    assert!(result.is_err());
 
     std::fs::remove_dir_all(&dir).unwrap();
 }

--- a/src-tauri/src/tests/relocator.rs
+++ b/src-tauri/src/tests/relocator.rs
@@ -51,7 +51,7 @@ fn preview_empty_when_no_folder_works() {
 #[test]
 fn preview_empty_when_path_unchanged() {
     let conn = setup_test_db();
-    insert_folder_work(&conn, "MyWork", "/library/MyWork", None);
+    insert_folder_work(&conn, "MyWork", "/library/works/MyWork", None);
     let previews =
         preview_relocation(&conn, TEST_LIBRARY_ID, Path::new("/library"), "{title}").unwrap();
     assert!(previews.is_empty());
@@ -70,7 +70,7 @@ fn preview_shows_changed_paths() {
     .unwrap();
     assert_eq!(previews.len(), 1);
     assert_eq!(previews[0].old_path, "/library/old_location");
-    assert_eq!(previews[0].new_path, "/library/Artist/MyWork");
+    assert_eq!(previews[0].new_path, "/library/works/Artist/MyWork");
     assert_eq!(previews[0].title, "MyWork");
 }
 

--- a/src-tauri/src/tests/scanner.rs
+++ b/src-tauri/src/tests/scanner.rs
@@ -79,3 +79,32 @@ fn has_image_subfolders_detects_deeply_nested_images() {
 
     assert!(has_image_subfolders(tmp.path()));
 }
+
+#[test]
+fn classify_path_detects_folder() {
+    let tmp = TempDir::new().unwrap();
+    assert_eq!(classify_path(tmp.path()), DropKind::Folder);
+}
+
+#[test]
+fn classify_path_detects_image() {
+    let tmp = TempDir::new().unwrap();
+    let img = tmp.path().join("photo.jpg");
+    fs::write(&img, b"fake").unwrap();
+    assert_eq!(classify_path(&img), DropKind::Image);
+}
+
+#[test]
+fn classify_path_rejects_non_image_file() {
+    let tmp = TempDir::new().unwrap();
+    let txt = tmp.path().join("note.txt");
+    fs::write(&txt, b"text").unwrap();
+    assert_eq!(classify_path(&txt), DropKind::Other);
+}
+
+#[test]
+fn classify_path_nonexistent_is_other() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("nothing.jpg");
+    assert_eq!(classify_path(&missing), DropKind::Other);
+}

--- a/src-tauri/src/tests/template.rs
+++ b/src-tauri/src/tests/template.rs
@@ -180,7 +180,7 @@ fn resolve_path_stays_under_root() {
         origin: None,
         work_type: None,
     };
-    let path = resolve_work_path(root, "{artist}/{title}", &meta);
+    let path = resolve_work_path(root, "{artist}/{title}", &meta, WORK_KIND_FOLDER);
     let path_str = path.to_string_lossy();
     assert!(
         path_str.starts_with("/library"),
@@ -192,15 +192,34 @@ fn resolve_path_stays_under_root() {
 #[test]
 fn resolve_path_simple() {
     let root = Path::new("/library");
-    let path = resolve_work_path(root, "{title}", &full_metadata());
-    assert_eq!(path, Path::new("/library/My Title"));
+    let path = resolve_work_path(root, "{title}", &full_metadata(), WORK_KIND_FOLDER);
+    assert_eq!(path, Path::new("/library/works/My Title"));
 }
 
 #[test]
 fn resolve_path_nested() {
     let root = Path::new("/library");
-    let path = resolve_work_path(root, "{artist}/{year}/{title}", &full_metadata());
-    assert_eq!(path, Path::new("/library/Artist A/2024/My Title"));
+    let path = resolve_work_path(
+        root,
+        "{artist}/{year}/{title}",
+        &full_metadata(),
+        WORK_KIND_FOLDER,
+    );
+    assert_eq!(path, Path::new("/library/works/Artist A/2024/My Title"));
+}
+
+#[test]
+fn resolve_path_image_kind_uses_pictures_prefix() {
+    let root = Path::new("/library");
+    let path = resolve_work_path(root, "{artist}/{title}", &full_metadata(), WORK_KIND_IMAGE);
+    assert_eq!(path, Path::new("/library/pictures/Artist A/My Title"));
+}
+
+#[test]
+fn top_level_for_defaults_to_works() {
+    assert_eq!(top_level_for(WORK_KIND_FOLDER), "works");
+    assert_eq!(top_level_for(WORK_KIND_IMAGE), "pictures");
+    assert_eq!(top_level_for("unknown"), "works");
 }
 
 // resolve_unique_work_path tests
@@ -210,18 +229,18 @@ fn resolve_unique_nonexistent_returns_base() {
     let dir = std::env::temp_dir().join("sharaku_test_unique_nonexist");
     let _ = std::fs::remove_dir_all(&dir);
 
-    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata());
-    assert_eq!(path, dir.join("My Title"));
+    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata(), WORK_KIND_FOLDER);
+    assert_eq!(path, dir.join("works/My Title"));
 }
 
 #[test]
 fn resolve_unique_existing_gets_suffix() {
     let dir = std::env::temp_dir().join("sharaku_test_unique_exist");
     let _ = std::fs::remove_dir_all(&dir);
-    let target = dir.join("My Title");
+    let target = dir.join("works/My Title");
     std::fs::create_dir_all(&target).unwrap();
 
-    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata());
+    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata(), WORK_KIND_FOLDER);
     assert_ne!(path, target);
     assert!(path
         .file_name()
@@ -237,12 +256,12 @@ fn resolve_unique_skips_existing_suffixes() {
     let dir = std::env::temp_dir().join("sharaku_test_unique_skip");
     let _ = std::fs::remove_dir_all(&dir);
 
-    let base = dir.join("My Title");
-    let first_suffix = dir.join("My Title_0001");
+    let base = dir.join("works/My Title");
+    let first_suffix = dir.join("works/My Title_0001");
     std::fs::create_dir_all(&base).unwrap();
     std::fs::create_dir_all(&first_suffix).unwrap();
 
-    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata());
+    let path = resolve_unique_work_path(&dir, "{title}", &full_metadata(), WORK_KIND_FOLDER);
     assert_eq!(path.file_name().unwrap().to_string_lossy(), "My Title_0002");
 
     std::fs::remove_dir_all(&dir).unwrap();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,7 +14,10 @@
   import { initImportQueueListener } from "./lib/stores/importQueue.svelte";
   import { initBannerAutoClose } from "./lib/stores/bannerAutoClose.svelte";
   import { initTheme } from "./lib/stores/theme.svelte";
+  import { addToast } from "./lib/stores/toast.svelte";
   import type {
+    DropKind,
+    ImportKind,
     Library,
     Tag,
     TagSearchMode,
@@ -39,6 +42,7 @@
   let libraryLoading = $state(true);
   let dragging = $state(false);
   let importSourcePath = $state<string | undefined>(undefined);
+  let importSourceKind = $state<ImportKind>("folder");
   let bulkImportRootPath = $state<string | undefined>(undefined);
   let bulkImportDroppedPaths = $state<string[] | undefined>(undefined);
   let pendingBulkImportEntries = $state<UnregisteredEntry[] | undefined>(
@@ -80,6 +84,7 @@
     currentView = "library";
     selectedWorkId = null;
     importSourcePath = undefined;
+    importSourceKind = "folder";
   }
 
   function handleBackToSettings() {
@@ -136,8 +141,8 @@
     }
   }
 
-  async function resolveFolderPath(path: string): Promise<string> {
-    return invoke<string>("resolve_drop_path", { path });
+  async function classifyDropPath(path: string): Promise<DropKind> {
+    return invoke<DropKind>("classify_drop_path", { path });
   }
 
   $effect(() => {
@@ -167,35 +172,39 @@
         dragging = false;
         const paths = event.payload.paths;
         if (paths.length > 1) {
-          Promise.all(paths.map((p) => resolveFolderPath(p)))
-            .then((resolved) => {
-              const unique = [...new Set(resolved)];
-              bulkImportDroppedPaths = unique;
-              bulkImportRootPath = undefined;
-              pendingBulkImportEntries = undefined;
-              currentView = "bulk-import";
-            })
-            .catch((e) => {
-              console.error("Drop path resolution failed:", e);
-            });
+          const unique = [...new Set(paths)];
+          bulkImportDroppedPaths = unique;
+          bulkImportRootPath = undefined;
+          pendingBulkImportEntries = undefined;
+          currentView = "bulk-import";
         } else if (paths.length === 1) {
-          resolveFolderPath(paths[0])
-            .then(async (folderPath) => {
-              const hasSubs = await invoke<boolean>("has_image_subfolders", {
-                dir: folderPath,
-              });
-              if (hasSubs) {
-                bulkImportRootPath = folderPath;
-                bulkImportDroppedPaths = undefined;
-                pendingBulkImportEntries = undefined;
-                currentView = "bulk-import";
-              } else {
-                importSourcePath = folderPath;
+          const path = paths[0];
+          classifyDropPath(path)
+            .then(async (kind) => {
+              if (kind === "folder") {
+                const hasSubs = await invoke<boolean>("has_image_subfolders", {
+                  dir: path,
+                });
+                if (hasSubs) {
+                  bulkImportRootPath = path;
+                  bulkImportDroppedPaths = undefined;
+                  pendingBulkImportEntries = undefined;
+                  currentView = "bulk-import";
+                } else {
+                  importSourcePath = path;
+                  importSourceKind = "folder";
+                  currentView = "import";
+                }
+              } else if (kind === "image") {
+                importSourcePath = path;
+                importSourceKind = "image";
                 currentView = "import";
+              } else {
+                addToast("error", "対応していないファイル形式です");
               }
             })
             .catch((e) => {
-              console.error("Drop path resolution failed:", e);
+              console.error("Drop classification failed:", e);
             });
         }
       }
@@ -293,6 +302,7 @@
       {:else if currentView === "import"}
         <ImportView
           initialSourcePath={importSourcePath}
+          initialKind={importSourceKind}
           onBack={handleBackToLibrary}
         />
       {:else if currentView === "bulk-import"}

--- a/src/app.css
+++ b/src/app.css
@@ -1374,6 +1374,11 @@ button:disabled {
   width: 32px;
 }
 
+.bulk-th-kind {
+  width: 56px;
+  text-align: center;
+}
+
 .bulk-th-count {
   width: 56px;
   text-align: center;
@@ -1388,6 +1393,10 @@ button:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.bulk-cell-kind {
+  text-align: center;
 }
 
 .bulk-cell-count {

--- a/src/lib/components/BulkImportView.svelte
+++ b/src/lib/components/BulkImportView.svelte
@@ -8,14 +8,23 @@
     ResourceMode,
     DiscoverResult,
     DiscoverProgress,
+    ImportKind,
     ImportMode,
     ImportRequest,
     EnqueueResult,
     UnregisteredEntry,
     ParsedMetadata,
     SkippedFolder,
-    DiscoveredFolder,
   } from "../types";
+
+  type BulkEntry = {
+    kind: ImportKind;
+    path: string;
+    displayName: string;
+    imageCount: number;
+    parsedMetadata: ParsedMetadata;
+    alreadyRegistered: boolean;
+  };
 
   interface Props {
     initialEntries?: UnregisteredEntry[];
@@ -33,7 +42,7 @@
   let step = $state<Step>("discover");
   let discovering = $state(false);
   let discoverStatus = $state("");
-  let folders = $state<DiscoveredFolder[]>([]);
+  let entries = $state<BulkEntry[]>([]);
   let skippedFolders = $state<SkippedFolder[]>([]);
   let showSkippedDetails = $state(false);
   let selected = new SvelteSet<number>();
@@ -41,6 +50,39 @@
   let editedArtists = new SvelteMap<number, string>();
   let mode = $state<ImportMode>("copy");
   let submitting = $state(false);
+
+  function buildEntriesFromResult(result: DiscoverResult): BulkEntry[] {
+    const folderEntries: BulkEntry[] = result.folders.map((f) => ({
+      kind: "folder",
+      path: f.path,
+      displayName: f.folderName,
+      imageCount: f.imageCount,
+      parsedMetadata: f.parsedMetadata,
+      alreadyRegistered: f.alreadyRegistered,
+    }));
+    const imageEntries: BulkEntry[] = result.images.map((img) => ({
+      kind: "image",
+      path: img.path,
+      displayName: img.fileName,
+      imageCount: 1,
+      parsedMetadata: img.parsedMetadata,
+      alreadyRegistered: img.alreadyRegistered,
+    }));
+    return [...folderEntries, ...imageEntries];
+  }
+
+  function applyDiscoverResult(result: DiscoverResult) {
+    entries = buildEntriesFromResult(result);
+    skippedFolders = result.skippedFolders;
+    showSkippedDetails = false;
+    selected.clear();
+    entries.forEach((e, i) => {
+      if (!e.alreadyRegistered) selected.add(i);
+    });
+    editedTitles.clear();
+    editedArtists.clear();
+    step = "review";
+  }
 
   async function discoverFromPath(rootPath: string) {
     discovering = true;
@@ -51,7 +93,7 @@
       if (p.type === "scanning") {
         discoverStatus = `${p.scannedDirs} フォルダを探索中...`;
       } else if (p.type === "completed") {
-        discoverStatus = `${p.found} 件のフォルダを検出`;
+        discoverStatus = `${p.found} 件を検出`;
       }
     };
 
@@ -60,18 +102,7 @@
         rootPath,
         onProgress: channel,
       });
-      folders = result.folders;
-      skippedFolders = result.skippedFolders;
-      showSkippedDetails = false;
-      selected.clear();
-      folders.forEach((f, i) => {
-        if (!f.alreadyRegistered) {
-          selected.add(i);
-        }
-      });
-      editedTitles.clear();
-      editedArtists.clear();
-      step = "review";
+      applyDiscoverResult(result);
     } catch (e) {
       discoverStatus = `エラー: ${e}`;
     } finally {
@@ -88,7 +119,7 @@
       if (p.type === "scanning") {
         discoverStatus = `${p.scannedDirs} フォルダを探索中...`;
       } else if (p.type === "completed") {
-        discoverStatus = `${p.found} 件のフォルダを検出`;
+        discoverStatus = `${p.found} 件を検出`;
       }
     };
 
@@ -97,18 +128,7 @@
         paths,
         onProgress: channel,
       });
-      folders = result.folders;
-      skippedFolders = result.skippedFolders;
-      showSkippedDetails = false;
-      selected.clear();
-      folders.forEach((f, i) => {
-        if (!f.alreadyRegistered) {
-          selected.add(i);
-        }
-      });
-      editedTitles.clear();
-      editedArtists.clear();
-      step = "review";
+      applyDiscoverResult(result);
     } catch (e) {
       discoverStatus = `エラー: ${e}`;
     } finally {
@@ -123,12 +143,12 @@
   }
 
   function getTitle(index: number): string {
-    return editedTitles.get(index) ?? folders[index].parsedMetadata.title;
+    return editedTitles.get(index) ?? entries[index].parsedMetadata.title;
   }
 
   function getArtist(index: number): string {
     return (
-      editedArtists.get(index) ?? folders[index].parsedMetadata.artist ?? ""
+      editedArtists.get(index) ?? entries[index].parsedMetadata.artist ?? ""
     );
   }
 
@@ -145,22 +165,22 @@
       selected.clear();
     } else {
       selected.clear();
-      folders.forEach((f, i) => {
-        if (!f.alreadyRegistered) selected.add(i);
+      entries.forEach((e, i) => {
+        if (!e.alreadyRegistered) selected.add(i);
       });
     }
   }
 
   let selectableCount = $derived(
-    folders.filter((f) => !f.alreadyRegistered).length,
+    entries.filter((e) => !e.alreadyRegistered).length,
   );
 
   async function executeImport() {
     const requests: ImportRequest[] = [];
     for (const index of selected) {
-      const folder = folders[index];
+      const entry = entries[index];
       requests.push({
-        sourcePath: folder.path,
+        sourcePath: entry.path,
         title: getTitle(index),
         artist: getArtist(index) || null,
         year: null,
@@ -168,6 +188,7 @@
         circle: null,
         origin: null,
         mode,
+        kind: entry.kind,
       });
     }
 
@@ -184,7 +205,7 @@
 
   function resetToDiscover() {
     step = "discover";
-    folders = [];
+    entries = [];
     skippedFolders = [];
     showSkippedDetails = false;
     selected.clear();
@@ -193,23 +214,24 @@
     discoverStatus = "";
   }
 
-  async function loadFromEntries(entries: UnregisteredEntry[]) {
+  async function loadFromEntries(items: UnregisteredEntry[]) {
     const parsed = await Promise.all(
-      entries.map((entry) =>
+      items.map((entry) =>
         invoke<ParsedMetadata>("parse_folder_name", {
           folderName: entry.folderName,
         }),
       ),
     );
-    folders = entries.map((entry, i) => ({
+    entries = items.map((entry, i) => ({
+      kind: "folder",
       path: entry.path,
-      folderName: entry.folderName,
+      displayName: entry.folderName,
       imageCount: entry.imageCount,
       parsedMetadata: parsed[i],
       alreadyRegistered: false,
     }));
     selected.clear();
-    folders.forEach((_, i) => selected.add(i));
+    entries.forEach((_, i) => selected.add(i));
     editedTitles.clear();
     editedArtists.clear();
     mode = "move";
@@ -254,7 +276,7 @@
     <section class="import-section">
       <h2>取り込み対象の確認</h2>
       <p class="import-description">
-        {folders.length} フォルダ検出 / {selected.size} 件選択中
+        {entries.length} 件検出 / {selected.size} 件選択中
       </p>
 
       {#if skippedFolders.length > 0}
@@ -313,7 +335,8 @@
           <thead>
             <tr>
               <th class="bulk-th-check"></th>
-              <th class="bulk-th-folder">フォルダ</th>
+              <th class="bulk-th-kind">種別</th>
+              <th class="bulk-th-folder">名前</th>
               <th class="bulk-th-count">画像数</th>
               <th class="bulk-th-title">タイトル</th>
               <th class="bulk-th-artist">アーティスト</th>
@@ -321,26 +344,29 @@
             </tr>
           </thead>
           <tbody>
-            {#each folders as folder, i (folder.path)}
-              <tr class:bulk-row-disabled={folder.alreadyRegistered}>
+            {#each entries as entry, i (entry.path)}
+              <tr class:bulk-row-disabled={entry.alreadyRegistered}>
                 <td>
                   <input
                     type="checkbox"
                     checked={selected.has(i)}
-                    disabled={folder.alreadyRegistered}
+                    disabled={entry.alreadyRegistered}
                     onchange={() => toggleSelect(i)}
                   />
                 </td>
-                <td class="bulk-cell-folder" title={folder.path}>
-                  {folder.folderName}
+                <td class="bulk-cell-kind">
+                  {entry.kind === "folder" ? "フォルダ" : "画像"}
                 </td>
-                <td class="bulk-cell-count">{folder.imageCount}</td>
+                <td class="bulk-cell-folder" title={entry.path}>
+                  {entry.displayName}
+                </td>
+                <td class="bulk-cell-count">{entry.imageCount}</td>
                 <td>
                   <input
                     type="text"
                     class="bulk-inline-input"
                     value={getTitle(i)}
-                    disabled={folder.alreadyRegistered}
+                    disabled={entry.alreadyRegistered}
                     oninput={(e) =>
                       editedTitles.set(i, (e.target as HTMLInputElement).value)}
                   />
@@ -350,7 +376,7 @@
                     type="text"
                     class="bulk-inline-input"
                     value={getArtist(i)}
-                    disabled={folder.alreadyRegistered}
+                    disabled={entry.alreadyRegistered}
                     oninput={(e) =>
                       editedArtists.set(
                         i,
@@ -359,7 +385,7 @@
                   />
                 </td>
                 <td class="bulk-cell-status">
-                  {#if folder.alreadyRegistered}
+                  {#if entry.alreadyRegistered}
                     <span class="bulk-registered">登録済み</span>
                   {:else}
                     <span class="bulk-new">新規</span>

--- a/src/lib/components/ImportView.svelte
+++ b/src/lib/components/ImportView.svelte
@@ -5,6 +5,7 @@
   import type {
     AppSettings,
     ResourceMode,
+    ImportKind,
     ImportMode,
     ImportRequest,
     EnqueueResult,
@@ -13,15 +14,19 @@
 
   interface Props {
     initialSourcePath?: string;
+    initialKind?: ImportKind;
     onBack: () => void;
   }
 
-  let { initialSourcePath, onBack }: Props = $props();
+  let { initialSourcePath, initialKind = "folder", onBack }: Props = $props();
 
   type Step = "select" | "metadata";
 
+  const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "gif", "webp", "bmp"];
+
   let resourceMode = $state<ResourceMode>("full");
   let step = $state<Step>("select");
+  let kind = $state<ImportKind>(initialKind);
   let sourcePath = $state("");
   let title = $state("");
   let artist = $state("");
@@ -35,27 +40,27 @@
   let debounceTimer = $state<ReturnType<typeof setTimeout> | null>(null);
   let previewRequestId = 0;
 
-  async function selectFolder() {
-    const selected = await open({ directory: true });
-    if (!selected) return;
+  function basenameOf(path: string): string {
+    const sep = path.includes("\\") ? "\\" : "/";
+    return path.split(sep).pop() ?? path;
+  }
 
-    sourcePath = selected;
-    const sep = selected.includes("\\") ? "\\" : "/";
-    const folderName = selected.split(sep).pop() ?? selected;
+  function stripExtension(fileName: string): string {
+    const dot = fileName.lastIndexOf(".");
+    return dot > 0 ? fileName.slice(0, dot) : fileName;
+  }
 
-    try {
-      const parsed = await invoke<ParsedMetadata>("parse_folder_name", {
-        folderName,
-      });
-      title = parsed.title;
-      artist = parsed.artist ?? "";
-    } catch {
-      title = folderName;
-      artist = "";
-    }
-
-    step = "metadata";
-    updatePreview();
+  async function selectSource() {
+    const selected =
+      kind === "folder"
+        ? await open({ directory: true })
+        : await open({
+            directory: false,
+            multiple: false,
+            filters: [{ name: "画像", extensions: IMAGE_EXTENSIONS }],
+          });
+    if (typeof selected !== "string") return;
+    await loadFromPath(selected);
   }
 
   function buildMetadata() {
@@ -84,6 +89,7 @@
       try {
         const path = await invoke<string>("preview_import_path", {
           metadata: buildMetadata(),
+          kind,
         });
         if (requestId !== previewRequestId) return;
         previewPath = path;
@@ -101,6 +107,7 @@
         sourcePath,
         ...buildMetadata(),
         mode,
+        kind,
       };
       await invoke<EnqueueResult>("enqueue_import", { requests: [request] });
       onBack();
@@ -126,17 +133,17 @@
 
   async function loadFromPath(path: string) {
     sourcePath = path;
-    const sep = path.includes("\\") ? "\\" : "/";
-    const folderName = path.split(sep).pop() ?? path;
+    const base = basenameOf(path);
+    const nameForParse = kind === "image" ? stripExtension(base) : base;
 
     try {
       const parsed = await invoke<ParsedMetadata>("parse_folder_name", {
-        folderName,
+        folderName: nameForParse,
       });
       title = parsed.title;
       artist = parsed.artist ?? "";
     } catch {
-      title = folderName;
+      title = nameForParse;
       artist = "";
     }
 
@@ -157,10 +164,24 @@
 {#if step === "select"}
   <div class="import-content">
     <section class="import-section">
-      <h2>フォルダを選択</h2>
-      <p class="import-description">取り込む画像フォルダを選択してください。</p>
-      <button class="import-select-btn" onclick={selectFolder}>
-        フォルダを選択...
+      <h2>取り込み対象を選択</h2>
+      <div class="import-kind-select">
+        <label class="import-mode-option">
+          <input type="radio" bind:group={kind} value="folder" />
+          フォルダ（複数画像）
+        </label>
+        <label class="import-mode-option">
+          <input type="radio" bind:group={kind} value="image" />
+          画像ファイル（1枚）
+        </label>
+      </div>
+      <p class="import-description">
+        {kind === "folder"
+          ? "取り込む画像フォルダを選択してください。"
+          : "取り込む画像ファイルを選択してください。"}
+      </p>
+      <button class="import-select-btn" onclick={selectSource}>
+        {kind === "folder" ? "フォルダを選択..." : "画像を選択..."}
       </button>
     </section>
   </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,10 @@ export interface WorkMetadata {
 
 export type ImportMode = "copy" | "move";
 
+export type ImportKind = "folder" | "image";
+
+export type DropKind = "folder" | "image" | "other";
+
 export interface ImportRequest {
   sourcePath: string;
   title: string;
@@ -88,6 +92,7 @@ export interface ImportRequest {
   circle: string | null;
   origin: string | null;
   mode: ImportMode;
+  kind: ImportKind;
 }
 
 export interface ImportResult {
@@ -121,6 +126,13 @@ export interface DiscoveredFolder {
   alreadyRegistered: boolean;
 }
 
+export interface DiscoveredImage {
+  path: string;
+  fileName: string;
+  parsedMetadata: ParsedMetadata;
+  alreadyRegistered: boolean;
+}
+
 export interface SkippedFolder {
   path: string;
   folderName: string;
@@ -129,6 +141,7 @@ export interface SkippedFolder {
 
 export interface DiscoverResult {
   folders: DiscoveredFolder[];
+  images: DiscoveredImage[];
   skippedFolders: SkippedFolder[];
 }
 

--- a/tests/components/BulkImportView.svelte.test.ts
+++ b/tests/components/BulkImportView.svelte.test.ts
@@ -95,11 +95,11 @@ describe("BulkImportView コンポーネント", () => {
       });
     });
 
-    it("検出フォルダ数と選択件数が表示される", async () => {
+    it("検出件数と選択件数が表示される", async () => {
       render(BulkImportView, createProps({ initialEntries: entries }));
 
       await waitFor(() => {
-        expect(screen.getByText(/2 フォルダ検出/)).toBeInTheDocument();
+        expect(screen.getByText(/2 件検出/)).toBeInTheDocument();
         expect(screen.getByText(/2 件選択中/)).toBeInTheDocument();
       });
     });

--- a/tests/components/ImportView.svelte.test.ts
+++ b/tests/components/ImportView.svelte.test.ts
@@ -46,7 +46,7 @@ describe("ImportView コンポーネント", () => {
 
     it("タイトルと説明が表示される", () => {
       render(ImportView, createProps());
-      expect(screen.getByText("フォルダを選択")).toBeInTheDocument();
+      expect(screen.getByText("取り込み対象を選択")).toBeInTheDocument();
       expect(
         screen.getByText("取り込む画像フォルダを選択してください。"),
       ).toBeInTheDocument();
@@ -135,7 +135,7 @@ describe("ImportView コンポーネント", () => {
       await user.click(screen.getByText("← 戻る"));
 
       await waitFor(() => {
-        expect(screen.getByText("フォルダを選択")).toBeInTheDocument();
+        expect(screen.getByText("取り込み対象を選択")).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
# Issue

close #164

# 変更点

- ライブラリ配下を `works/`（フォルダ作品）と `pictures/`（単体画像）にトップレベル分岐
- 画像ファイルをドロップした際、親フォルダの取り込みを廃止し、その画像1枚を単体作品としてインポートする挙動に変更
- ImportView にフォルダ/画像の切替ラジオを追加し、画像モード時はファイル選択ダイアログを使用
- BulkImportView でフォルダと単体画像を混在した1つのテーブルに列挙（種別カラムで判別）
- 複数ドロップやフォルダ+画像の混在ドロップをそれぞれ個別の作品として処理
- `scanner::classify_path` と `DropKind` を追加し、フロント側でパスを先に分類してから分岐
- `importer::import_single_image` を新設し、`import_work` と並ぶ API として import queue から種別ごとに dispatch

# 備考

- 破壊的変更: 既存のフォルダ作品は `{library}/{artist}/{title}/` から `{library}/works/{artist}/{title}/` に配置が変わる。相当の relocate/マイグレーションは実装していない（未リリース・ユーザー不在前提）
- 単体画像作品の relocate は当面対象外（`relocator.rs` は folder 作品のみ扱う）
- ドラッグ&ドロップの手動動作確認はスキップ（macOS のアクセシビリティ権限の制約で自動スクリーンショットが取れず、Tauri native window でしか試せないため）
