### PR TITLE
Fix svelte-check warnings for state initialization and label association

### DIFF
--- a/src/lib/components/EditWorkDialog.svelte
+++ b/src/lib/components/EditWorkDialog.svelte
@@ -11,11 +11,17 @@
 
   let { work, onClose, onUpdated }: Props = $props();
 
+  // svelte-ignore state_referenced_locally
   let title = $state(work.title);
+  // svelte-ignore state_referenced_locally
   let artist = $state(work.artist ?? "");
+  // svelte-ignore state_referenced_locally
   let year = $state(work.year?.toString() ?? "");
+  // svelte-ignore state_referenced_locally
   let genre = $state(work.genre ?? "");
+  // svelte-ignore state_referenced_locally
   let circle = $state(work.circle ?? "");
+  // svelte-ignore state_referenced_locally
   let origin = $state(work.origin ?? "");
   let saving = $state(false);
 

--- a/src/lib/components/ImportView.svelte
+++ b/src/lib/components/ImportView.svelte
@@ -28,6 +28,7 @@
 
   let resourceMode = $state<ResourceMode>("full");
   let step = $state<Step>("select");
+  // svelte-ignore state_referenced_locally
   let kind = $state<ImportKind>(initialKind);
   let sourcePath = $state("");
   let title = $state("");
@@ -283,8 +284,14 @@
 
         {#if resourceMode === "full"}
           <div class="import-field">
-            <label class="import-label">取り込みモード</label>
-            <div class="import-mode-select">
+            <span id="import-mode-label" class="import-label"
+              >取り込みモード</span
+            >
+            <div
+              class="import-mode-select"
+              role="radiogroup"
+              aria-labelledby="import-mode-label"
+            >
               <label class="import-mode-option">
                 <input type="radio" bind:group={mode} value="copy" />
                 コピー

--- a/src/lib/components/SetupView.svelte
+++ b/src/lib/components/SetupView.svelte
@@ -17,6 +17,7 @@
     "{type}/{artist}/{title}",
   ];
 
+  // svelte-ignore state_referenced_locally
   let step = $state<
     "welcome" | "mode-select" | "select" | "template" | "name-only"
   >(initialStep);


### PR DESCRIPTION
# 変更点

- master 時点で `npm run check`（svelte-check）に残っていた既存警告9件を解消
- `state_referenced_locally` 8件（ImportView.svelte / SetupView.svelte / EditWorkDialog.svelte）: propの初期値を意図的にキャプチャする正当なパターンのため、動作を変えず該当行に `// svelte-ignore state_referenced_locally` を付与して抑制
- `a11y_label_has_associated_control` 1件（ImportView.svelte「取り込みモード」）: コントロールなし `<label>` を `<span>` に変更し、ラジオグループ側に `role="radiogroup"` + `aria-labelledby` を付与して構造的に解消

## 補足

- `npm run check` は 0 errors / 0 warnings、`npm run lint` / `npm run format:check` も通過を確認済み
- ImportView の取り込みモードUIについて、Playwrightで表示崩れがないこと・radiogroupのアクセシブル名が正しく取得できることを確認済み
